### PR TITLE
♻️ Refactor: 엔티티 & 설정 파일 & 주석 정리

### DIFF
--- a/src/main/java/callprotector/spring/client/FastClient.java
+++ b/src/main/java/callprotector/spring/client/FastClient.java
@@ -12,36 +12,27 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
-// Client 폴더: 외부 API 통신 전담
-// 역할: Spring 애플리케이션 내부에서 외부 서버(Flask 등)에 HTTP 요청을 보내는 모듈을 담당
-// - 일반적으로 Flask, 외부 API 서버, DB 외부 서비스, Microservice 등과 통신할 때 사용
-// - 통신 로직을 서비스에서 분리하여 **비즈니스 로직(Service)**이 더 깔끔하게 유지됨
+@Slf4j
+@Component
+@RequiredArgsConstructor
 
-@Slf4j // 자동 로깅 라이브러리
-@Component // Spring이 FlaskClient 객체를 자동으로 생성해서 관리하도록 만드는 것 (이 클래스를 Spring Bean으로 등록해라!!)
-@RequiredArgsConstructor // Component랑 RequiredArgsConstructor랑 같이 쓰면, @Autowired 주입 없이도 사용 가능
-// 왜 필요해? -> Spring에서 FlaskClient를 new로 만들지 않고, """Spring 내부에서 생성·주입 관리하도록""" 하기 위함
+public class FastClient {
 
-public class FastClient { // Service는 비즈니스 로직만 전담하고, Client는 외부 시스템과의 연결 전담
-
-    private final RestTemplate restTemplate; // final 필드에 대해 자동으로 생성자 만들어 줌
+    private final RestTemplate restTemplate;
 
     private static final String FASTAPI_URL = "http://localhost:8080/filter-abuse";
 
     public AbuseResponseDTO.AbuseFilterDTO sendTextToFastAPI(String text) {
-        // 1. 요청 헤더 설정 (Content-Type: application/json)
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, String> requestBody = Map.of("text", text);
         HttpEntity<Map<String, String>> entity = new HttpEntity<>(requestBody, headers);
 
-        // Spring의 RestTemplate: 외부 HTTP 서버에 요청을 보내는 도구
-        // postForEntity = POST요청을 보내고, 응답을 ResponseEntity로 받겠다.
         ResponseEntity<AbuseResponseDTO.AbuseFilterDTO> response = restTemplate.postForEntity(
-                FASTAPI_URL, // 요청 보낼 URL
-                entity, // 요청 본문 (JSON으로 변환됨)
-                AbuseResponseDTO.AbuseFilterDTO.class // 응답 받을 DTO 클래스
+                FASTAPI_URL,
+                entity,
+                AbuseResponseDTO.AbuseFilterDTO.class
         );
 
         AbuseResponseDTO.AbuseFilterDTO result = response.getBody();
@@ -57,5 +48,3 @@ public class FastClient { // Service는 비즈니스 로직만 전담하고, Cli
     }
 
 }
-
-// Servie: 업무 처리자, Client: 외부 심부름꾼

--- a/src/main/java/callprotector/spring/config/RestTemplateConfig.java
+++ b/src/main/java/callprotector/spring/config/RestTemplateConfig.java
@@ -3,28 +3,12 @@ package callprotector.spring.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
-// config 폴더: 설정 파일 전용
-// - 역할: Spring의 전역 설정을 담당
-// - - 공통적으로 애플리케이션 전체에서 사용하는 구성 요소(Bean)를 정의
-// - - ex) RestTemplate, WebClient, CORS 설정, Swagger 설정, ObjectMapper 설정 등
-
 
 @Configuration
-// Spring의 설정파일 (application.yml과 달리, 자바 코드로 Bean 등록하는 방식)
-// 역할: 이 클래스 안에 있는 메서드들을 보고, Spring이 Bean 객체 생성하고 관리함
-// 이 클래스는 설정용 클래스다 ! Spring이 특별하게 취급해야 해 !
 public class RestTemplateConfig {
 
-    @Bean // 해당 메서드의 리턴 값을 Spring이 Bean으로 등록하라 ㅇㅇ
-    // 즉 -> RestTemplate 객체를 Spring 컨테이너가 관리하도록 만드는 것.
-    // 역할: 나중에 다른 클래스에서 @Autowired나 @RequiredArgsConstructor를 쓰면, 이 Bean이 자동으로 주입됨.
+    @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
-    } // 이 메서드가 리턴하는 RestTemplate 인스턴스를 하나 만들어서 Spring이 관리해준다 ㅇㅇ
+    }
 }
-
-
-// 결과적으로 무슨 일이 벌어지냐면...
-// 1. RestTemplateConfig 클래스 → 설정 클래스 (@Configuration)
-// 2. restTemplate() 메서드 실행 → Bean 등록 (@Bean)
-// 3. """다른 클래스에서 의존성 주입"""으로 사용 가능!

--- a/src/main/java/callprotector/spring/config/WebSecurityConfig.java
+++ b/src/main/java/callprotector/spring/config/WebSecurityConfig.java
@@ -52,10 +52,6 @@ public class WebSecurityConfig
                                     .requestMatchers(
                                             "/health",
                                             "/api/auth/**", // 전체 인증 관련 요청 허용
-                                            "/api/auth/send-code",   // 인증 없이 접근 허용
-                                            "/api/auth/verify-code", // 인증 코드 확인도 포함
-                                            "/api/auth/signup",
-                                            "/api/auth/login",
                                             "/v3/api-docs/**",
                                             "/swagger-ui/**",
                                             "/swagger-resources/**",

--- a/src/main/java/callprotector/spring/config/WebSecurityConfig.java
+++ b/src/main/java/callprotector/spring/config/WebSecurityConfig.java
@@ -51,7 +51,7 @@ public class WebSecurityConfig
                             authorizeRequests
                                     .requestMatchers(
                                             "/health",
-                                            "/api/auth/**", // 전체 인증 관련 요청 허용
+                                            "/api/auth/**",
                                             "/v3/api-docs/**",
                                             "/swagger-ui/**",
                                             "/swagger-resources/**",

--- a/src/main/java/callprotector/spring/domain/User.java
+++ b/src/main/java/callprotector/spring/domain/User.java
@@ -26,7 +26,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(nullable = false, length = 20, unique = true)
+    @Column(nullable = false, length = 200, unique = true)
     private String email;
 
     //@Column(nullable = false, length = 16) <- 에러 방지 위해, 일단 주석 : 당장 회원가입 시 사용하지 않기 때문에
@@ -46,7 +46,7 @@ public class User extends BaseEntity {
     private Long totalCall = 0L;
 
     @Column(nullable = false, length = 15)
-    private Long phoneNumber;
+    private String phoneNumber;
 
     //@LastModifiedDate <- 에러 방지 위해,  일단 주석
     private LocalDateTime updatedAt;

--- a/src/main/java/callprotector/spring/domain/User.java
+++ b/src/main/java/callprotector/spring/domain/User.java
@@ -6,7 +6,6 @@ import callprotector.spring.domain.common.BaseEntity;
 import callprotector.spring.domain.mapping.LegalBotQuery;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/callprotector/spring/service/UserService/UserServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/UserService/UserServiceImpl.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.Random;
 
@@ -89,7 +88,7 @@ public class UserServiceImpl implements UserService{
                 .name(dto.getName())
                 .email(dto.getEmail())
                 .password(passwordEncoder.encode(dto.getPassword()))
-                .phoneNumber(Long.valueOf(dto.getPhone()))
+                .phoneNumber(String.valueOf(dto.getPhone()))
                 .build();
 
         User savedUser = userRepository.save(user);

--- a/src/main/java/callprotector/spring/web/dto/request/AbuseRequestDTO.java
+++ b/src/main/java/callprotector/spring/web/dto/request/AbuseRequestDTO.java
@@ -7,23 +7,15 @@ import lombok.NoArgsConstructor;
 
 public class AbuseRequestDTO {
 
-
-    @Builder // DTO에도 빌더 패턴 쓴다? -> 그냥 우리가 만드는 인스턴스들은 모두 빌더 패턴 사용한다고 보면 됨
-             // 참고로 RequestDTO는 우리가 만드는 것이 아닌, 프론트엔드에서 만든 객체를 그저 받기에, 빌더 패턴 적용할 필요 X
+    @Builder
     @Getter
-    @NoArgsConstructor // 기본 생성자 초기화
-    @AllArgsConstructor // 모든 필드 초기화
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class AbuseFilterDTO{
-        // public static class 쓰는 이유:
-        // - DTO들은 저렇게 큰 묶음으로 (멤버 관련 DTO등등..) 클래스를 만들고
-        // - 내부적으로 static 클래스를 만드는 것이 좋습니다.
-        // DTO 자체는 수많은 곳에서 사용이 될 수 있기에 static class 로 만들게 되면,
-        // 매번 class 파일을 만들 필요도 없고, 범용적으로 DTO를 사용할 수 있습니다.
-
         private String text;
 
         public String getText() { return text; }
         public void setText(String text) { this.text = text;}
-
     }
+
 }

--- a/src/main/java/callprotector/spring/web/dto/response/AbuseResponseDTO.java
+++ b/src/main/java/callprotector/spring/web/dto/response/AbuseResponseDTO.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 
 public class AbuseResponseDTO {
 
-
     @Builder
     @Getter
     @NoArgsConstructor
@@ -17,20 +16,11 @@ public class AbuseResponseDTO {
         private boolean detected;
         private String type;
 
-        // Java에서 생성자의 이름은 반드시 클래스 이름과 같아야 한다!!!!!
-        // ㅁㅊ.. 기본을 까먹다니;;
-        // AbuseFilterDTO로 함수 이름 수정 간다. -> @AllArgsConstructor 가 다 해주잖
-
-
         public boolean isAbuse() { return abuse; };
 
         public boolean isDetected() { return detected;}
 
         public String getType() { return type; }
-
-
-
     }
-
 
 }


### PR DESCRIPTION
## 📌 작업 내용
- User 엔티티 및 WebSecurityConfig 관련 코드 및 주석을 리팩토링 하였습니다.

## 📝 변경 사항
- [x] User 엔티티 email 필드 length 20 -> 200으로 변경
- [x] User 엔티티 phoneNumber 필드 long -> string으로 변경
- [x] WebSecurityConfig 불필요한 url 제거
- [x] 주석 정리

## 🔗 관련 이슈
- closes #77

## 📸 스크린샷 (선택)
