### PR TITLE
✨ Feat: 상담 내역 조회 내 검색 기능 구현

### DIFF
--- a/Dockerfile.elasticsearch
+++ b/Dockerfile.elasticsearch
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+RUN elasticsearch-plugin install analysis-nori

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,15 @@ dependencies {
 	// Jackson JSR310 Datatype (Java 8 Date/Time API support)
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+	// Elasticsearch Java API Client
+	implementation 'co.elastic.clients:elasticsearch-java:8.13.0'
+	implementation 'org.elasticsearch.client:elasticsearch-rest-client:8.13.0'
+
+	// JSON 직렬화용 Jackson
+	implementation 'jakarta.json:jakarta.json-api:2.1.1'
+	implementation 'org.glassfish:jakarta.json:2.0.1'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: elasticsearch
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+
+volumes:
+  esdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: "3.8"
-
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    build:
+      context: .
+      dockerfile: Dockerfile.elasticsearch
     container_name: elasticsearch
     ports:
       - "9200:9200"

--- a/src/main/java/callprotector/spring/config/ElasticsearchConfig.java
+++ b/src/main/java/callprotector/spring/config/ElasticsearchConfig.java
@@ -1,0 +1,52 @@
+package callprotector.spring.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.http.HttpHost;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.elasticsearch.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(ElasticsearchConfig.ElasticsearchProperties.class)
+@RequiredArgsConstructor
+public class ElasticsearchConfig {
+
+    private final ElasticsearchProperties properties;
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        RestClient restClient = RestClient.builder(
+                new HttpHost(properties.getHost(), properties.getPort(), "http")
+        ).build();
+
+        ElasticsearchTransport transport = new RestClientTransport(
+                restClient,
+                new JacksonJsonpMapper(objectMapper)
+        );
+
+        return new ElasticsearchClient(transport);
+    }
+
+    @Getter
+    @Setter
+    @ConfigurationProperties(prefix = "elasticsearch")
+    public static class ElasticsearchProperties {
+        private String host;
+        private int port;
+    }
+}
+
+

--- a/src/main/java/callprotector/spring/domain/CallSttLog.java
+++ b/src/main/java/callprotector/spring/domain/CallSttLog.java
@@ -3,6 +3,7 @@ package callprotector.spring.domain;
 import java.time.LocalDateTime;
 
 import callprotector.spring.domain.enums.CallTrack;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,5 +58,6 @@ public class CallSttLog {
 
     @CreatedDate
     @Field("created_at")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime timestamp;
 }

--- a/src/main/java/callprotector/spring/elasticsearch/CallSttLogIndexConfig.java
+++ b/src/main/java/callprotector/spring/elasticsearch/CallSttLogIndexConfig.java
@@ -1,0 +1,83 @@
+package callprotector.spring.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CallSttLogIndexConfig {
+
+    private final ElasticsearchClient esClient;
+    private static final String INDEX_NAME = "call_stt_log";
+
+    private static final String INDEX_DEFINITION_JSON = """
+    {
+      "settings": {
+        "analysis": {
+          "tokenizer": {
+            "nori_tokenizer_custom": {
+              "type": "nori_tokenizer",
+              "decompound_mode": "mixed"
+            }
+          },
+          "analyzer": {
+            "nori_mixed_analyzer": {
+              "type": "custom",
+              "tokenizer": "nori_tokenizer_custom"
+            }
+          }
+        }
+      },
+      "mappings": {
+        "properties": {
+          "call_session_id": { "type": "long" },
+          "track":           { "type": "keyword" },
+          "script": {
+            "type": "text",
+            "analyzer": "nori_mixed_analyzer",
+            "search_analyzer": "nori_mixed_analyzer"
+          },
+          "is_abuse":   { "type": "boolean" },
+          "abuse_type": { "type": "keyword" },
+          "created_at": { "type": "date" },
+          "timestamp": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      }
+    }
+    """;
+
+    @PostConstruct
+    public void recreateIndex() throws IOException {
+        boolean exists = esClient.indices().exists(e -> e.index(INDEX_NAME)).value();
+
+        // 인덱스 수정 시 삭제 로직 - 주석 해제 후 사용
+//        if (exists) {
+//            esClient.indices().delete(d -> d.index(INDEX_NAME));
+//            log.info("🗑️ 기존 call_stt_log 인덱스 삭제 완료");
+//            exists = false;
+//        }
+
+        if (exists) {
+            log.info("ℹ️ call_stt_log 인덱스가 이미 존재합니다. 생성 생략");
+            return;
+        }
+
+        esClient.indices().create(c -> c
+                .index(INDEX_NAME)
+                .withJson(new ByteArrayInputStream(INDEX_DEFINITION_JSON.getBytes(StandardCharsets.UTF_8)))
+        );
+
+        log.info("✅ call_stt_log 인덱스 생성 완료");
+    }
+}

--- a/src/main/java/callprotector/spring/elasticsearch/CallSttLogIndexer.java
+++ b/src/main/java/callprotector/spring/elasticsearch/CallSttLogIndexer.java
@@ -1,0 +1,53 @@
+package callprotector.spring.elasticsearch;
+
+import callprotector.spring.domain.CallSttLog;
+import callprotector.spring.repository.CallSttLogRepository;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CallSttLogIndexer {
+
+    private final CallSttLogRepository callSttLogRepository;
+    private final ElasticsearchClient esClient;
+
+    @EventListener(ApplicationReadyEvent.class) // 애플리케이션 시작 시 실행
+    public void reindexAllLogs() throws IOException {
+        List<CallSttLog> mongoLogs = callSttLogRepository.findAll();
+
+        log.info("📦 MongoDB에서 불러온 CallSttLog 개수: {}", mongoLogs.size());
+
+        List<BulkOperation> operations = mongoLogs.stream()
+                .map(log -> BulkOperation.of(b -> b
+                        .index(i -> i
+                                .index("call_stt_log")
+                                .document(log)
+                        )))
+                .toList();
+
+        BulkRequest bulkRequest = BulkRequest.of(b -> b.operations(operations));
+        BulkResponse response = esClient.bulk(bulkRequest);
+
+        if (response.errors()) {
+            log.error("❌ 일부 문서 이관 실패: {}",
+                    response.items().stream()
+                            .filter(item -> item.error() != null)
+                            .toList()
+            );
+        } else {
+            log.info("🚀 Elasticsearch 재색인 완료: {}건", mongoLogs.size());
+        }
+    }
+}

--- a/src/main/java/callprotector/spring/repository/CallSessionRepositoryCustom.java
+++ b/src/main/java/callprotector/spring/repository/CallSessionRepositoryCustom.java
@@ -10,4 +10,5 @@ public interface CallSessionRepositoryCustom {
     List<CallSession> findByCursor(String sortBy, Object cursorValue, int limit, Sort.Direction direction);
 
     List<CallSession> findSessionsByAbuseCategory(String category, Long cursorId, int limit, Sort.Direction direction);
+    List<CallSession> findByIdsWithOrder(List<Long> ids, Sort.Direction direction);
 }

--- a/src/main/java/callprotector/spring/repository/CallSessionRepositoryImpl.java
+++ b/src/main/java/callprotector/spring/repository/CallSessionRepositoryImpl.java
@@ -60,4 +60,15 @@ public class CallSessionRepositoryImpl implements CallSessionRepositoryCustom {
 
         return query.getResultList();
     }
+
+    @Override
+    public List<CallSession> findByIdsWithOrder(List<Long> ids, Sort.Direction direction) {
+        if (ids.isEmpty()) return List.of();
+
+        String jpql = "SELECT cs FROM CallSession cs WHERE cs.id IN :ids ORDER BY cs.createdAt " + (direction.isAscending() ? "ASC" : "DESC");
+
+        return em.createQuery(jpql, CallSession.class)
+                .setParameter("ids", ids)
+                .getResultList();
+    }
 }

--- a/src/main/java/callprotector/spring/repository/CallSttLogSearchRepository.java
+++ b/src/main/java/callprotector/spring/repository/CallSttLogSearchRepository.java
@@ -1,0 +1,17 @@
+package callprotector.spring.repository;
+
+import callprotector.spring.domain.CallSttLog;
+
+import java.util.List;
+
+public interface CallSttLogSearchRepository {
+
+    List<CallSttLog> searchByKeywordAndFilters(
+            String keyword,
+            String category,
+            String order,
+            Long cursorId,
+            int size
+    );
+
+}

--- a/src/main/java/callprotector/spring/repository/CallSttLogSearchRepositoryImpl.java
+++ b/src/main/java/callprotector/spring/repository/CallSttLogSearchRepositoryImpl.java
@@ -1,0 +1,90 @@
+package callprotector.spring.repository;
+
+import callprotector.spring.domain.CallSttLog;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.JsonData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class CallSttLogSearchRepositoryImpl implements CallSttLogSearchRepository {
+
+    private final ElasticsearchClient esClient;
+    private static final String INDEX_NAME = "call_stt_log";
+
+    @Override
+    public List<CallSttLog> searchByKeywordAndFilters(String keyword, String category, String order, Long cursorId, int size) {
+        try {
+            List<Query> mustQueries = new ArrayList<>();
+
+            // keyword full-text 검색 (script)
+            if (keyword != null && !keyword.isBlank()) {
+                mustQueries.add(MatchQuery.of(m -> m
+                        .field("script")
+                        .query(keyword)
+                )._toQuery());
+            }
+
+            // 카테고리 필터
+            if (category != null && !category.isBlank()) {
+                mustQueries.add(TermQuery.of(t -> t
+                        .field("abuse_type")
+                        .value(category)
+                )._toQuery());
+            }
+
+            // 커서 기반 페이징
+            if (cursorId != null) {
+                mustQueries.add(RangeQuery.of(r -> r
+                        .field("call_session_id")
+                        .gt(JsonData.of(cursorId))
+                )._toQuery());
+            }
+
+            // 정렬
+            boolean isDesc = order == null || order.equalsIgnoreCase("desc");
+
+            log.info("🔍 Elasticsearch 검색 keyword='{}', category='{}', order='{}', cursorId={}, size={}", keyword, category, order, cursorId, size);
+
+            SearchRequest request = SearchRequest.of(s -> s
+                    .index(INDEX_NAME)
+                    .query(q -> q
+                            .bool(b -> b
+                                    .must(mustQueries)
+                            )
+                    )
+                    .sort(sort -> sort
+                            .field(f -> f
+                                    .field("created_at")
+                                    .order(isDesc ? SortOrder.Desc : SortOrder.Asc)
+                            )
+                    )
+                    .size(size)
+            );
+
+            SearchResponse<CallSttLog> response = esClient.search(request, CallSttLog.class);
+            List<CallSttLog> results = new ArrayList<>();
+            for (Hit<CallSttLog> hit : response.hits().hits()) {
+                results.add(hit.source());
+            }
+
+            return results;
+
+        } catch (IOException e) {
+            log.error("Elasticsearch 검색 중 오류 발생", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionService.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionService.java
@@ -12,6 +12,7 @@ public interface CallSessionService {
     void forceTerminateCall(CallSession callSession);
     CallSessionResponseDTO.CallSessionPagingDTO getCallSessions(String sortBy, String order, Long cursorId, int size);
     CallSessionResponseDTO.CallSessionPagingDTO getSessionsByAbuseCategory(String category, Long cursorId, int size, String order);
+    CallSessionResponseDTO.CallSessionPagingDTO searchCallSessions(String keyword, String category, String order, Long cursorId, int size);
     CallSessionResponseDTO.CallSessionDetailResponseDTO getCallSessionDetail(Long callSessionId);
     String generateGeminiSummary(Long callSessionId);
     CallSessionResponseDTO.CallSessionSummaryResponseDTO createCallSessionSummary(Long callSessionId);

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -21,9 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Locale;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.twilio.rest.api.v2010.account.Call;
@@ -42,6 +40,7 @@ public class CallSessionServiceImpl implements CallSessionService {
     private final AbuseLogRepository abuseLogRepository;
     private final AbuseTypeLogRepository abuseTypeLogRepository;
     private final CallLogRepository callLogRepository;
+    private final CallSttLogSearchRepository callSttLogSearchRepository;
     private final GeminiService geminiService;
 
     @Override
@@ -266,6 +265,52 @@ public class CallSessionServiceImpl implements CallSessionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public CallSessionResponseDTO.CallSessionPagingDTO searchCallSessions(String keyword, String category, String order, Long cursorId, int size) {
+        // Elasticsearch에서 CallSttLog 검색
+        List<CallSttLog> sttLogs = callSttLogSearchRepository.searchByKeywordAndFilters(keyword, category, order, cursorId, size + 1);
+
+        // callSessionId → script 매핑
+        Map<Long, String> sessionScriptMap = sttLogs.stream()
+                .collect(Collectors.toMap(
+                        CallSttLog::getCallSessionId,
+                        CallSttLog::getScript,
+                        (existing, replacement) -> existing // 중복 키 발생 시 첫 번째 script 유지
+                ));
+
+        // CallSession ID 추출
+        List<Long> sessionIds = new ArrayList<>(sessionScriptMap.keySet()).stream()
+                .limit(size + 1)
+                .toList();
+
+        // 세션 정렬 후 조회
+        Sort.Direction direction = order.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+        List<CallSession> sessions = callSessionRepository.findByIdsWithOrder(sessionIds, direction);
+
+        // DTO 변환
+        boolean hasNext = sessionIds.size() > size;
+        Long nextCursorId = hasNext ? sessionIds.get(size - 1) : null;
+
+        List<CallSessionResponseDTO.CallSessionListDTO> resultList = sessions.stream()
+                .limit(size)
+                .map(session -> {
+                    String resolvedCategory = getAbuseCategoryForSession(session);
+                    String fullScript = sessionScriptMap.get(session.getId());
+                    String matchedScript = extractSnippetAroundKeyword(fullScript, keyword, 15);
+                    return CallSessionResponseDTO.CallSessionListDTO.fromEntityWithScript(session, resolvedCategory, matchedScript);
+                })
+                .toList();
+
+        log.info("📌 keyword: {}, category: {}, order: {}, cursorId: {}, size: {}", keyword, category, order, cursorId, size); //추가
+
+        return CallSessionResponseDTO.CallSessionPagingDTO.builder()
+                .sessions(resultList)
+                .hasNext(hasNext)
+                .nextCursorId(nextCursorId)
+                .build();
+    }
+
+    @Override
     public String generateGeminiSummary(Long callSessionId) {
         CallSession session = findCallSessionById(callSessionId);
 
@@ -351,6 +396,19 @@ public class CallSessionServiceImpl implements CallSessionService {
         return "전체";
     }
 
+    // 검색어가 포함된 scrpit 일부만 추출하여 반환하는 함수
+    private String extractSnippetAroundKeyword(String script, String keyword, int contextLength) {
+        if (script == null || keyword == null || keyword.isBlank()) return null;
+
+        int index = script.indexOf(keyword);
+        if (index == -1) return null; // 검색어가 없으면 null 반환
+
+        int start = index;
+        int end = Math.min(script.length(), index + keyword.length() + contextLength);
+
+        return script.substring(start, end).replaceAll("\\s+", " ").trim();
+    }
+
     private CallSession findCallSessionById(final Long callSessionId) {
         return callSessionRepository.findById(callSessionId).orElseThrow(CallSessionNotFoundException::new);
     }
@@ -362,7 +420,6 @@ public class CallSessionServiceImpl implements CallSessionService {
             .totalAbuseCnt(callSession.getTotalAbuseCnt())
             .build();
     }
-
 
     private List<CallSessionResponseDTO.CallSessionScriptDTO> mapToScriptDTO(List<CallSttLog> scriptLogs) {
 

--- a/src/main/java/callprotector/spring/service/CallSttLogService/CallSttLogServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSttLogService/CallSttLogServiceImpl.java
@@ -1,16 +1,16 @@
 package callprotector.spring.service.CallSttLogService;
 
-import callprotector.spring.apiPayload.exception.handler.CallSttLogNotFoundException;
 import callprotector.spring.domain.CallSttLog;
 import callprotector.spring.domain.enums.CallTrack;
 import callprotector.spring.repository.CallSttLogRepository;
-import callprotector.spring.service.CallSessionService.CallSessionService;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.LinkedHashSet;
@@ -22,11 +22,13 @@ import java.util.stream.Collectors;
 public class CallSttLogServiceImpl implements CallSttLogService {
     private static final boolean IS_FINAL = true;
     private final CallSttLogRepository callSttLogRepository;
+    private final ElasticsearchClient elasticsearchClient;
 
     @Override
     @Transactional
     public CallSttLog saveTranscriptLog(Long callSessionId, CallTrack track, String script, boolean isFinal, boolean isAbuse, String abuseType) {
         Integer abuseCnt = isAbuse ? 1 : 0;
+
         CallSttLog sttLog = CallSttLog.builder()
                 .callSessionId(callSessionId)
                 .track(track)
@@ -45,6 +47,18 @@ public class CallSttLogServiceImpl implements CallSttLogService {
         //     log.info("STT 결과 욕설 감지 - (isAbuse={}) / CallSession total_abuse_cnt 업데이트 시도 - CallSessionId={}", isAbuse, callSessionId);
         //     callSessionService.incrementTotalAbuseCnt(callSessionId);
         // }
+
+        // Elasticsearch 인덱싱
+        try {
+            elasticsearchClient.index(i -> i
+                    .index("call_stt_log")
+                    .id(savedSttLog.getId())
+                    .document(savedSttLog)
+            );
+            log.info("Elasticsearch - CallSttLog 인덱싱 완료: id={}", savedSttLog.getId());
+        } catch (IOException e) {
+            log.error("❌ Elasticsearch 인덱싱 실패 - id: {}", savedSttLog.getId(), e);
+        }
 
         return savedSttLog;
     }

--- a/src/main/java/callprotector/spring/web/controller/CallSessionController.java
+++ b/src/main/java/callprotector/spring/web/controller/CallSessionController.java
@@ -8,11 +8,13 @@ import callprotector.spring.web.dto.response.CallSessionResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/sessions")
@@ -32,25 +34,48 @@ public class CallSessionController {
                 .build());
     }
 
-    @Operation(summary = "상담 내역 조회 API", description = "카테고리별 상담 내역을 페이지네이션 방식으로 조회합니다.")
+    @Operation(
+            summary = "상담 내역 조회 API",
+            description = "검색어(keyword), 폭언 카테고리(category), 정렬 순서(order), 커서 기반 페이지네이션(cursorId)을 기반으로 상담 내역을 조회합니다."
+    )
     @GetMapping("")
     public ApiResponse<CallSessionResponseDTO.CallSessionPagingDTO> getCallSessions(
+
+            @Parameter(description = "검색 키워드")
+            @RequestParam(required = false) String keyword,
+
             @Parameter(description = "현재 페이지의 기준이 되는 마지막 CallSession ID")
             @RequestParam(required = false) Long cursorId,
 
-            @Parameter(description = "가져올 데이터 개수")
+            @Parameter(description = "가져올 데이터 개수 (기본값: 5)")
             @RequestParam(defaultValue = "5") int size,
 
-            @Parameter(description = "정렬 순서 (desc, asc)")
+            @Parameter(description = "정렬 순서 (desc: 최신순, asc: 오래된 순)")
             @RequestParam(defaultValue = "desc") String order,
 
-            @Parameter(description = "폭언 카테고리 (verbalAbuse, sexualHarass, threat)")
+            @Parameter(description = "폭언 유형 카테고리 (verbalAbuse | sexualHarass | threat)")
             @RequestParam(required = false) String category
     ) {
-        if (category != null) {
-            return ApiResponse.onSuccess(callSessionService.getSessionsByAbuseCategory(category, cursorId, size, order));
+        // 키워드가 존재하는 경우: Elasticsearch 검색 수행
+        if (keyword != null && !keyword.isBlank()) {
+            log.info("🔍 키워드 검색 요청 - keyword={}, category={}, order={}, cursorId={}, size={}",
+                    keyword, category, order, cursorId, size);
+            return ApiResponse.onSuccess(
+                    callSessionService.searchCallSessions(keyword, category, order, cursorId, size)
+            );
         }
-        return ApiResponse.onSuccess(callSessionService.getCallSessions("id", order, cursorId, size));
+
+        // 카테고리만 존재하는 경우: 필터 기반 조회
+        if (category != null && !category.isBlank()) {
+            return ApiResponse.onSuccess(
+                    callSessionService.getSessionsByAbuseCategory(category, cursorId, size, order)
+            );
+        }
+
+        // 기본 전체 조회 (정렬 기준: ID)
+        return ApiResponse.onSuccess(
+                callSessionService.getCallSessions("id", order, cursorId, size)
+        );
     }
 
     @Operation(summary = "callSession 상세 조회", description = "상담 내역 상세 조회 시 callSession을 조회합니다.")
@@ -64,7 +89,7 @@ public class CallSessionController {
     }
 
     @Operation(
-            summary = "AI 상담 요약 생성 API",
+            summary = "AI 상담 요약 생성 API - OpenAI GPT",
             description = "CallSession ID를 기반으로 고객과 상담원의 통화 내용을 요약하여 CallSession의 summary 필드에 저장합니다."
     )
     @PostMapping("/{sessionId}/summary")

--- a/src/main/java/callprotector/spring/web/dto/response/CallSessionResponseDTO.java
+++ b/src/main/java/callprotector/spring/web/dto/response/CallSessionResponseDTO.java
@@ -74,6 +74,8 @@ public class CallSessionResponseDTO {
         private LocalDateTime createdAt;
         private String category;
 
+        private String matchedScript;
+
         public static CallSessionListDTO fromEntity(CallSession session, String category) {
             return CallSessionListDTO.builder()
                     .id(session.getId())
@@ -81,6 +83,18 @@ public class CallSessionResponseDTO {
                     .callerNumber(session.getCallerNumber())
                     .createdAt(session.getCreatedAt())
                     .category(category)
+                    .build();
+        }
+
+        // 검색 사용 시 응답
+        public static CallSessionListDTO fromEntityWithScript(CallSession session, String category, String matchedScript) {
+            return CallSessionListDTO.builder()
+                    .id(session.getId())
+                    .callSessionCode(session.getCallSessionCode())
+                    .callerNumber(session.getCallerNumber())
+                    .createdAt(session.getCreatedAt())
+                    .category(category)
+                    .matchedScript(matchedScript)
                     .build();
         }
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,3 +53,6 @@ gcp:
   location:
     id: ${GCP_LOCATION_ID}
 
+elasticsearch:
+  host: localhost
+  port: 9200

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,3 +52,7 @@ gcp:
     id: ${GCP_PROJECT_ID}
   location:
     id: ${GCP_LOCATION_ID}
+
+elasticsearch:
+  host: localhost
+  port: 9200


### PR DESCRIPTION
## 📌 작업 내용
- elasticsearch를 이용하여 상담 내역 조회 내 검색 기능을 구현했습니다. 

## 📝 변경 사항
- [x] 상담 내역 조회 내 검색 기능 API 구현

## 🔗 관련 이슈
- closes #75 

## 📸 스크린샷 (선택)
<img width="958" height="566" alt="상담내역조회1" src="https://github.com/user-attachments/assets/7cf95610-5bf9-47ef-b5db-45c022790269" />
<img width="955" height="284" alt="상담내역조회2" src="https://github.com/user-attachments/assets/594d8490-32c7-4891-875b-1571bfd99693" />

