### PR TITLE
✨ Feat: CallSession 정상 종료 시 endedAt 필드 처리 로직 추가

### DIFF
--- a/src/main/java/callprotector/spring/handler/TwilioMediaStreamProcessor.java
+++ b/src/main/java/callprotector/spring/handler/TwilioMediaStreamProcessor.java
@@ -58,6 +58,15 @@ public class TwilioMediaStreamProcessor {
 		log.info("Closing STTContexts for CallSessionId: {}", currentCallSessionId);
 		// sttContexts 맵에 저장된 모든 STTContext 인스턴스에 대해 closeStream() 호출
 		sttContexts.values().forEach(SttContext::closeStream);
+
+		// CallSession의 endedAt 필드 업데이트
+		if (currentCallSessionId == null) {
+			log.warn("CallSession ID가 null이므로, endedAt을 업데이트할 수 없습니다.");
+			return;
+		}
+
+		callSessionService.updateEndedAt(currentCallSessionId);
+
 		// 세션 관련 정보 초기화
 		currentUserId = null;
 		currentCallSessionId = null;

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionService.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionService.java
@@ -16,4 +16,5 @@ public interface CallSessionService {
     CallSessionResponseDTO.CallSessionDetailResponseDTO getCallSessionDetail(Long callSessionId);
     String generateGeminiSummary(Long callSessionId);
     CallSessionResponseDTO.CallSessionSummaryResponseDTO createCallSessionSummary(Long callSessionId);
+    void updateEndedAt(Long callSessionId);
 }

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -278,6 +278,7 @@ public class CallSessionServiceImpl implements CallSessionService {
     }
 
     @Override
+    @Transactional
     public String generateGeminiSummary(Long callSessionId) {
         CallSession session = findCallSessionById(callSessionId);
 

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -330,6 +330,7 @@ public class CallSessionServiceImpl implements CallSessionService {
     }
 
     @Override
+    @Transactional
     public CallSessionResponseDTO.CallSessionSummaryResponseDTO createCallSessionSummary(Long callSessionId) {
         String summaryText = generateGeminiSummary(callSessionId);
 

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -69,8 +69,7 @@ public class CallSessionServiceImpl implements CallSessionService {
     @Override
     @Transactional(readOnly = true)
     public CallSessionResponseDTO.CallSessionInfoDTO getCallSessionInfo(final Long callSessionId) {
-        CallSession callSession = callSessionRepository.findById(callSessionId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 CallSession이 존재하지 않습니다. ID: " + callSessionId));
+        CallSession callSession = findCallSessionById(callSessionId);
 
         String formattedCreatedAt = formatCreatedAt(callSession.getCreatedAt());
 

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -205,6 +205,7 @@ public class CallSessionServiceImpl implements CallSessionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CallSessionResponseDTO.CallSessionPagingDTO getSessionsByAbuseCategory(String category, Long cursorId, int size, String order) {
         validateAbuseCategory(category);
 

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -370,6 +370,14 @@ public class CallSessionServiceImpl implements CallSessionService {
             .build();
     }
 
+    @Override
+    @Transactional
+    public void updateEndedAt(final Long callSessionId) {
+        CallSession session = findCallSessionById(callSessionId);
+        session.updateEndedAt();
+        log.info("CallSession (ID: {})의 endedAt 업데이트 완료 : {}", callSessionId, session.getEndedAt());
+    }
+
     private void validateAbuseCategory(String category) {
         List<String> valid = List.of("verbalAbuse", "sexualHarass", "threat");
         if (!valid.contains(category)) {

--- a/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/CallSessionService/CallSessionServiceImpl.java
@@ -175,40 +175,7 @@ public class CallSessionServiceImpl implements CallSessionService {
             .build();
     }
 
-    private String formatCreatedAt(LocalDateTime createdAt) {
-        String datePart = createdAt.format(DateTimeFormatter.ofPattern("M.d", Locale.KOREA));
-        String timePart = createdAt.format(DateTimeFormatter.ofPattern("HH:mm", Locale.KOREA));
-        String dayKor = getKoreanDayOfWeek(createdAt.getDayOfWeek());
 
-        return String.format("%s (%s) %s", datePart, dayKor, timePart);
-    }
-
-    private String getKoreanDayOfWeek(DayOfWeek dayOfWeek) {
-		return switch (dayOfWeek) {
-			case MONDAY -> "월";
-			case TUESDAY -> "화";
-			case WEDNESDAY -> "수";
-			case THURSDAY -> "목";
-			case FRIDAY -> "금";
-			case SATURDAY -> "토";
-			case SUNDAY -> "일";
-		};
-    }
-
-    // 발신번호 포맷팅 함수
-    private String formatKoreanPhoneNumber(String rawNumber) {
-        if (rawNumber == null || rawNumber.isBlank()) return null;
-
-        // +82로 시작하는 국제번호 처리
-        if (rawNumber.startsWith("+82")) {
-            String local = rawNumber.substring(3);
-            if (local.startsWith("10") && local.length() == 10) {
-                return "010-" + local.substring(2, 6) + "-" + local.substring(6);
-            }
-        }
-
-        return rawNumber;
-    }
 
     @Override
     @Transactional(readOnly = true)
@@ -418,6 +385,41 @@ public class CallSessionServiceImpl implements CallSessionService {
 
     private CallSession findCallSessionById(final Long callSessionId) {
         return callSessionRepository.findById(callSessionId).orElseThrow(CallSessionNotFoundException::new);
+    }
+
+    private String formatCreatedAt(LocalDateTime createdAt) {
+        String datePart = createdAt.format(DateTimeFormatter.ofPattern("M.d", Locale.KOREA));
+        String timePart = createdAt.format(DateTimeFormatter.ofPattern("HH:mm", Locale.KOREA));
+        String dayKor = getKoreanDayOfWeek(createdAt.getDayOfWeek());
+
+        return String.format("%s (%s) %s", datePart, dayKor, timePart);
+    }
+
+    private String getKoreanDayOfWeek(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    // 발신번호 포맷팅 함수
+    private String formatKoreanPhoneNumber(String rawNumber) {
+        if (rawNumber == null || rawNumber.isBlank()) return null;
+
+        // +82로 시작하는 국제번호 처리
+        if (rawNumber.startsWith("+82")) {
+            String local = rawNumber.substring(3);
+            if (local.startsWith("10") && local.length() == 10) {
+                return "010-" + local.substring(2, 6) + "-" + local.substring(6);
+            }
+        }
+
+        return rawNumber;
     }
 
     private CallSessionResponseDTO.CallSessionInfoDTO mapToSessionInfoDTO(CallSession callSession) {


### PR DESCRIPTION
## 📌 작업 내용
- Feat: CallSession 정상 종료 시 endedAt 필드 처리 로직을 추가합니다.

## 📝 변경 사항
- [x] CallSession 정보 조회 시, 내부 메서드로 CallSession 객체 조회하도록 로직 변경
- [x] CallSession endedAt 필드 업데이트 메서드 구현 및 적용
  - 각 레이어 간의 책임 분리를 위해 endedAt을 변경하는 비즈니스 로직을 서비스 레이어에서 처리하도록 수정하였습니다.
- [x] CallSessionServiceImpl의 내부 메서드 위치 변경
- [x] CallSessionServiceImpl 일부 메서드에 누락된 @Transactional 추가

## 🔗 관련 이슈
- closes #91

## 📸 스크린샷 (선택)
<img width="692" height="252" alt="image" src="https://github.com/user-attachments/assets/60eccc88-f903-4f79-b81b-c43b61b872e9" />

