### PR TITLE
✨ Feat: 인증 인가 추가 구현

### DIFF
--- a/src/main/java/callprotector/spring/annotation/UserId.java
+++ b/src/main/java/callprotector/spring/annotation/UserId.java
@@ -1,0 +1,17 @@
+package callprotector.spring.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression="#this")
+@Parameter(hidden = true)
+public @interface UserId {
+}

--- a/src/main/java/callprotector/spring/apiPayload/exception/handler/UserNotFoundException.java
+++ b/src/main/java/callprotector/spring/apiPayload/exception/handler/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package callprotector.spring.apiPayload.exception.handler;
+
+import callprotector.spring.apiPayload.code.status.ErrorStatus;
+import callprotector.spring.apiPayload.exception.GeneralException;
+
+public class UserNotFoundException extends GeneralException {
+	public UserNotFoundException() {
+
+      super(ErrorStatus.USER_NOT_FOUND);
+	}
+}

--- a/src/main/java/callprotector/spring/repository/UserRepository.java
+++ b/src/main/java/callprotector/spring/repository/UserRepository.java
@@ -10,12 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
 
-    // 일단 이메일 중복 체크 메서드 추가추가
     boolean existsByEmail(String email);
 
-    // 이메일로 사용자 조회
     Optional<User> findByEmail(String email);
-
-    // userId를 추가해야되나 고민이네.. ㅇㅅㅇ
-    // Optional<User> findByUserId(String userId);
 }

--- a/src/main/java/callprotector/spring/security/JwtAuthenticationFilter.java
+++ b/src/main/java/callprotector/spring/security/JwtAuthenticationFilter.java
@@ -35,11 +35,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("Filter is running...");
 
             if (token != null && !token.equalsIgnoreCase("null")) {
-                String email = tokenProvider.validateAndGetUserEmail(token);
-                log.info("Authenticated user Email: " + email);
+                // String email = tokenProvider.validateAndGetUserEmail(token);
+                // log.info("Authenticated user Email: " + email);
+
+                Long userId = tokenProvider.validateAndGetUserId(token);
+                log.info("Authenticated user Id: " + userId);
 
                 AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        email,
+                        userId, // email
                         null,
                         AuthorityUtils.NO_AUTHORITIES
                 );

--- a/src/main/java/callprotector/spring/security/TokenProvider.java
+++ b/src/main/java/callprotector/spring/security/TokenProvider.java
@@ -25,6 +25,7 @@ public class TokenProvider {
         return Jwts.builder()
                 .signWith(key, SignatureAlgorithm.HS512) // signWith 파라미터 순서 변경
                 .setSubject(user.getEmail())
+                .claim("userId", user.getId())
                 .setIssuer("callprotector web")
                 .setIssuedAt(new Date())
                 .setExpiration(expiryDate)
@@ -38,5 +39,15 @@ public class TokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
         return claims.getSubject();
+    }
+
+    public Long validateAndGetUserId(String token) {
+        Claims claims = Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+
+        return claims.get("userId", Long.class);
     }
 }

--- a/src/main/java/callprotector/spring/service/UserService/UserService.java
+++ b/src/main/java/callprotector/spring/service/UserService/UserService.java
@@ -7,12 +7,13 @@ import callprotector.spring.web.dto.response.UserResponseDTO;
 public interface UserService {
 
     public UserResponseDTO.SignupDTO create(final UserRequestDTO.SignupDTO dto);
+
     public UserResponseDTO.LoginDTO login(final UserRequestDTO.LoginDTO dto);
 
     public void sendVerificationCode(String email);
 
     public void verifyCode(String email, String code);
 
-    public User getUserByEmail(String email);
+    public User getUserById(Long id);
 
 }

--- a/src/main/java/callprotector/spring/service/UserService/UserServiceImpl.java
+++ b/src/main/java/callprotector/spring/service/UserService/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package callprotector.spring.service.UserService;
 
+import callprotector.spring.apiPayload.exception.handler.UserNotFoundException;
 import callprotector.spring.domain.User;
 import callprotector.spring.domain.VerificationToken;
 import callprotector.spring.repository.UserRepository;
@@ -66,14 +67,6 @@ public class UserServiceImpl implements UserService{
         token.markVerified(); // verified = true 로 표시
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public User getUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
-    }
-
-
     // 회원가입
     @Override
     @Transactional
@@ -123,4 +116,9 @@ public class UserServiceImpl implements UserService{
                 .build();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
+    }
 }

--- a/src/main/java/callprotector/spring/web/controller/ChatSessionController.java
+++ b/src/main/java/callprotector/spring/web/controller/ChatSessionController.java
@@ -1,16 +1,17 @@
 package callprotector.spring.web.controller;
 
+import callprotector.spring.annotation.UserId;
 import callprotector.spring.apiPayload.ApiResponse;
 import callprotector.spring.domain.User;
 import callprotector.spring.service.ChatSessionService.ChatSessionService;
 import callprotector.spring.service.UserService.UserService;
 import callprotector.spring.web.dto.response.ChatSessionResponseDTO;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,10 +22,10 @@ public class ChatSessionController {
     private final UserService userService;
 
     @PostMapping
-    public ApiResponse<ChatSessionResponseDTO.ChatSessionResponse> createSession(Principal principal) {
-        String email = principal.getName();  // JWT에서 추출된 email 값
-        User user = userService.getUserByEmail(email); // UserService에서 조회
+    public ApiResponse<ChatSessionResponseDTO.ChatSessionResponse> createSession(
+        @UserId Long userId
+    ) {
+        User user = userService.getUserById(userId);
         return ApiResponse.onSuccess(chatSessionService.createSession(user));
     }
-
 }

--- a/src/main/java/callprotector/spring/web/controller/TestController.java
+++ b/src/main/java/callprotector/spring/web/controller/TestController.java
@@ -1,0 +1,21 @@
+package callprotector.spring.web.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import callprotector.spring.annotation.UserId;
+import callprotector.spring.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class TestController {
+
+	@GetMapping("/api/test/my-info")
+	public ApiResponse<String> getMyInfo(@UserId Long userId) {
+		log.info("인증된 사용자의 ID: {}", userId);
+		return ApiResponse.onSuccess("User ID " + userId + "님의 정보를 성공적으로 조회했습니다.");
+	}
+}


### PR DESCRIPTION
## 📌 작업 내용
- 인증 인가 추가 구현

JWT(JSON Web Token)에 사용자 고유 식별자(userId)를 포함시키고, 이를 안전하게 추출할 수 있는 기능을 도입합니다. 기존에는 JWT에 사용자 이메일(subject)만 포함되어 있었으나, 서비스 내에서 사용자 ID를 직접적으로 활용해야 하는 요구사항이 증가함에 따라 userId 클레임을 추가하게 되었습니다. 이를 통해 토큰 기반 인증 과정에서 사용자 식별의 유연성과 정확성을 높이고, 향후 컨트롤러에서 사용자 ID를 직접 주입받을 수 있는 기반을 마련합니다.
Spring Security의 @AuthenticationPrincipal 어노테이션을 활용하여, 인증된 사용자의 ID를 컨트롤러 메서드의 파라미터로 직접 주입받을 수 있는 @UserId 커스텀 어노테이션을 구현합니다. 기존에는 SecurityContextHolder에서 직접 principal을 꺼내어 캐스팅하는 방식이 필요했지만, @UserId 어노테이션을 통해 코드의 가독성과 편의성을 크게 향상시킵니다.
JWT 기반 인증 필터(JwtAuthenticationFilter)에서 Spring Security의 Authentication 객체를 생성할 때, principal (인증 주체)로 사용되던 사용자 이메일(String) 대신 사용자 고유 ID(Long)를 사용하도록 변경합니다. 이 변경은 principal에 더 구체적인 사용자 식별 정보를 직접 저장함으로써, @UserId 어노테이션과 같은 커스텀 어노테이션을 통해 컨트롤러에서 사용자 ID를 직접 주입받을 수 있는 기반을 완성합니다.

또한, 현재 서비스 상 로그인한 유저는 모든 기능에 접근할 수 있으므로, UserDetails는 구현하지 않고 간단하게 구현합니다.

## 📝 변경 사항
- [x] 토큰 생성 시 사용자 이메일(subject) 외에 사용자 고유 ID(userId) 클레임 추가
- [x] @AuthenticationPrincipal 어노테이션을 활용한 @UserId 커스텀 어노테이션 도입
- [x] TokenProvider로부터 추출한 userId (Long 타입)를 직접 principal로 설정하도록 변경
  - [ ] 기존 코드는 삭제 예정
- [x] @UserId 커스텀 어노테이션이 올바르게 동작하는지 확인하기 위한 테스트용 API 엔드포인트(/api/test/my-info) 추가
  - [ ] 해당 코드는 삭제 예정

## 🔗 관련 이슈
- closes #101

## 📸 스크린샷 (선택)
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/ad7fb7f5-19ab-4b8a-9c08-a2d05555504e" />
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/6418f847-c019-4d3b-84bd-8a3ac960f598" />

