### PR TITLE
♻️  Refactor: 일반 채팅 API 기능 구현 완료 

### DIFF
--- a/src/main/java/callprotector/spring/domain/chat/controller/ChatSessionController.java
+++ b/src/main/java/callprotector/spring/domain/chat/controller/ChatSessionController.java
@@ -23,9 +23,7 @@ public class ChatSessionController {
     private final UserService userService;
 
     @PostMapping
-    public ApiResponse<ChatSessionResponseDTO.ChatSessionResponse> createSession(
-        @UserId Long userId
-    ) {
+    public ApiResponse<ChatSessionResponseDTO.ChatSessionResponse> createSession(@UserId Long userId) {
         User user = userService.getUserById(userId);
         return ApiResponse.onSuccess(chatSessionService.createSession(user));
     }

--- a/src/main/java/callprotector/spring/domain/chat/controller/ChatSessionController.java
+++ b/src/main/java/callprotector/spring/domain/chat/controller/ChatSessionController.java
@@ -1,5 +1,6 @@
 package callprotector.spring.domain.chat.controller;
 
+import callprotector.spring.domain.chat.entity.ChatSession;
 import callprotector.spring.global.annotation.UserId;
 import callprotector.spring.global.apiPayload.ApiResponse;
 import callprotector.spring.domain.user.entity.User;
@@ -9,9 +10,9 @@ import callprotector.spring.domain.chat.dto.response.ChatSessionResponseDTO;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,4 +29,15 @@ public class ChatSessionController {
         User user = userService.getUserById(userId);
         return ApiResponse.onSuccess(chatSessionService.createSession(user));
     }
+
+    
+    // userId에 해당하는 채팅세션 조회 API
+    @GetMapping("/list")
+    public ApiResponse<List<ChatSessionResponseDTO.ChatSessionResponse>>  getSessionList(@UserId Long userId) {
+        return ApiResponse.onSuccess(chatSessionService.getSessionList(userId));
+    }
+
+
+
+
 }

--- a/src/main/java/callprotector/spring/domain/chat/controller/ChatStreamController.java
+++ b/src/main/java/callprotector/spring/domain/chat/controller/ChatStreamController.java
@@ -27,42 +27,39 @@ public class ChatStreamController {
 
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> streamChat(@RequestParam Long sessionId, @RequestParam String question) {
-
-        StringBuilder fullAnswer = new StringBuilder();
+        StringBuilder jsonBuffer = new StringBuilder();
 
         return webClient.post()
                 .uri("/stream")
                 .bodyValue(Map.of("session_id", sessionId, "question", question))
                 .retrieve()
                 .bodyToFlux(String.class)
-                .map(data -> data.replace("data:", ""))
-                .doOnNext(fullAnswer::append)
+                .map(data -> data.replace("data:", "").trim())
+                .doOnNext(chunk -> {
+                    if (chunk.startsWith("[JSON]")) {
+                        String jsonPart = chunk.replace("[JSON]", "").trim();
+                        jsonBuffer.append(jsonPart);
+                    }
+                })
                 .doOnComplete(() -> {
                     try {
-                        String cleaned = fullAnswer.toString()
-                                .replace("```json", "")
-                                .replace("```", "")
-                                .replace("data:", "")
-                                .replace("[END]", "")
-                                .trim();
+                        if (jsonBuffer.length() > 0) {
+                            log.info("📥 최종 JSON: {}", jsonBuffer);
 
-                        int firstBraceIndex = cleaned.indexOf("{");
-                        int lastBraceIndex = cleaned.lastIndexOf("}");
-                        if (firstBraceIndex == -1 || lastBraceIndex == -1) {
-                            log.error("❌ JSON 추출 실패: {}", cleaned);
-                            return;
+                            // ✅ JSON 키 공백 정리
+                            String normalizedJson = jsonBuffer.toString()
+                                    .replaceAll("\"\\s*([^\"]*?)\\s*\"\\s*:", "\"$1\":")
+                                    .replaceAll(":\\s*\"\\s*([^\"]*?)\\s*\"", ":\"$1\"");
+
+                            ObjectMapper mapper = new ObjectMapper();
+                            JsonNode jsonNode = mapper.readTree(normalizedJson);
+
+                            String answer = jsonNode.get("answer").asText();
+                            log.info("💾 DB 저장 전 answer: {}", answer);
+
+                            String sourcePages = mapper.writeValueAsString(jsonNode.get("sourcePages"));
+                            chatLogService.saveChatLog(sessionId, question, answer, sourcePages);
                         }
-                        String jsonString = cleaned.substring(firstBraceIndex, lastBraceIndex + 1);
-
-                        log.info("📥 FastAPI 응답 (정제 후): {}", jsonString);
-
-                        ObjectMapper mapper = new ObjectMapper();
-                        JsonNode jsonNode = mapper.readTree(jsonString);
-
-                        String answer = jsonNode.get("answer").asText();
-                        String sourcePages = mapper.writeValueAsString(jsonNode.get("sourcePages"));
-
-                        chatLogService.saveChatLog(sessionId, question, answer, sourcePages);
                     } catch (Exception e) {
                         log.error("❌ JSON 파싱 오류", e);
                     }

--- a/src/main/java/callprotector/spring/domain/chat/controller/ChatStreamController.java
+++ b/src/main/java/callprotector/spring/domain/chat/controller/ChatStreamController.java
@@ -1,6 +1,9 @@
 package callprotector.spring.domain.chat.controller;
 
+import callprotector.spring.domain.chat.entity.ChatSession;
 import callprotector.spring.domain.chat.service.ChatLogService;
+import callprotector.spring.domain.chat.service.ChatSessionService;
+import callprotector.spring.global.ai.OpenAiService.OpenAiTitleService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,8 @@ public class ChatStreamController {
 
     private final WebClient webClient = WebClient.create("http://localhost:8000"); // FastAPI URL
     private final ChatLogService chatLogService;
+    private final ChatSessionService chatSessionService;
+    private final OpenAiTitleService openAiTitleService;
 
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> streamChat(@RequestParam Long sessionId, @RequestParam String question) {
@@ -59,6 +64,12 @@ public class ChatStreamController {
 
                             String sourcePages = mapper.writeValueAsString(jsonNode.get("sourcePages"));
                             chatLogService.saveChatLog(sessionId, question, answer, sourcePages);
+
+                            // ✅ 첫 질문이면 세션 타이틀 생성
+                            ChatSession session = chatSessionService.getSessionById(sessionId);
+                            if (session.getTitle() == null || session.getTitle().isBlank()) {
+                                chatSessionService.updateTitleIfEmpty(session, question);
+                            }
                         }
                     } catch (Exception e) {
                         log.error("❌ JSON 파싱 오류", e);

--- a/src/main/java/callprotector/spring/domain/chat/dto/request/ChatbotRequestDTO.java
+++ b/src/main/java/callprotector/spring/domain/chat/dto/request/ChatbotRequestDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// request 폴더 살리려고 일단 냅둠
 public class ChatbotRequestDTO {
 
     @Builder

--- a/src/main/java/callprotector/spring/domain/chat/dto/response/ChatLogResponseDTO.java
+++ b/src/main/java/callprotector/spring/domain/chat/dto/response/ChatLogResponseDTO.java
@@ -1,6 +1,7 @@
 package callprotector.spring.domain.chat.dto.response;
 
 import lombok.*;
+import java.util.List;
 
 public class ChatLogResponseDTO {
 
@@ -12,7 +13,7 @@ public class ChatLogResponseDTO {
         private Long id;
         private String question;
         private String answer;
-        private String sourcePages;
+        private List<SourcePageDTO.SourcePage> sourcePages; // 문자열 대신 리스트로 수정
         private String createdAt;
     }
 

--- a/src/main/java/callprotector/spring/domain/chat/dto/response/ChatSessionResponseDTO.java
+++ b/src/main/java/callprotector/spring/domain/chat/dto/response/ChatSessionResponseDTO.java
@@ -14,6 +14,7 @@ public class ChatSessionResponseDTO {
     public static class ChatSessionResponse{
         private Long sessionId;
         private String startTime;
+        private String title;
     }
 
 }

--- a/src/main/java/callprotector/spring/domain/chat/dto/response/SourcePageDTO.java
+++ b/src/main/java/callprotector/spring/domain/chat/dto/response/SourcePageDTO.java
@@ -5,16 +5,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
-public class ChatbotResponseDTO {
+public class SourcePageDTO {
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChatbotResponse{
-        private String answer;
-        private List<String> sourcePages;
+    public static class SourcePage{
+        private String 유형;
+        private String 관련법률;
     }
 }

--- a/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
+++ b/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
@@ -29,7 +29,9 @@ public class ChatSession extends BaseEntity {
     private LocalDateTime endTime;
 
     @Column(nullable = false)
-    private Integer status;
+    private Integer status; // 1. 진행 중, 2:종료
+
+    private String title; // title 필드 추가
 
 
     @OneToMany(mappedBy = "chatSession", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
+++ b/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
@@ -31,6 +31,7 @@ public class ChatSession extends BaseEntity {
     @Column(nullable = false)
     private Integer status; // 1. 진행 중, 2:종료
 
+    @Setter
     private String title; // title 필드 추가
 
 

--- a/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
+++ b/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
@@ -4,7 +4,12 @@ import callprotector.spring.domain.chat.entity.ChatSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
+
 @Repository
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+
+    List<ChatSession> findByUserIdOrderByStartTimeDesc(Long userId);
 
 }

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatLogServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatLogServiceImpl.java
@@ -1,9 +1,12 @@
 package callprotector.spring.domain.chat.service;
 
+import callprotector.spring.domain.chat.dto.response.SourcePageDTO;
 import callprotector.spring.domain.chat.entity.ChatLog;
 import callprotector.spring.domain.chat.entity.ChatSession;
 import callprotector.spring.domain.chat.repository.ChatLogRepository;
 import callprotector.spring.domain.chat.dto.response.ChatLogResponseDTO;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +22,7 @@ public class ChatLogServiceImpl implements ChatLogService {
 
     private final ChatLogRepository chatLogRepository;
     private final ChatSessionService chatSessionService; // 리포지터리 대신 서비스에 의존하기
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 파싱용
 
 
     // SSE 용 saveChatLog (ChatStreamController가 호출함)
@@ -41,13 +45,25 @@ public class ChatLogServiceImpl implements ChatLogService {
     @Transactional(readOnly = true)
     public List<ChatLogResponseDTO.ChatLogResponse> getChatLogsBySession(Long sessionId) {
         return chatLogRepository.findAllByChatSessionId(sessionId).stream()
-                .map(log -> ChatLogResponseDTO.ChatLogResponse.builder()
-                        .id(log.getId())
-                        .question(log.getQuestion())
-                        .answer(log.getAnswer())
-                        .sourcePages(log.getSourcePages()) // 추가
-                        .createdAt(log.getCreatedAt().toString())
-                        .build())
+                .map(log -> {
+                    List<SourcePageDTO.SourcePage> sourcePagesList;
+                    try {
+                        sourcePagesList = objectMapper.readValue(
+                                log.getSourcePages(),
+                                new TypeReference<>() {} // Java 11이상에서는 타입 추론 가능
+                        );
+                    } catch (Exception e) {
+                        sourcePagesList = List.of(); // 파싱 실패 시 빈 리스트 반환 (타입 추론 자동 적용)
+                    }
+
+                    return ChatLogResponseDTO.ChatLogResponse.builder()
+                            .id(log.getId())
+                            .question(log.getQuestion())
+                            .answer(log.getAnswer())
+                            .sourcePages(sourcePagesList) // ✅ 리스트로 반환
+                            .createdAt(log.getCreatedAt().toString())
+                            .build();
+                })
                 .toList();
     }
 

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatSessionService.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatSessionService.java
@@ -4,12 +4,17 @@ import callprotector.spring.domain.chat.entity.ChatSession;
 import callprotector.spring.domain.user.entity.User;
 import callprotector.spring.domain.chat.dto.response.ChatSessionResponseDTO;
 
+import java.util.List;
+
 
 public interface ChatSessionService {
 
-    public ChatSession getSessionById(Long sessionId);
+    ChatSession getSessionById(Long sessionId);
 
     ChatSessionResponseDTO.ChatSessionResponse createSession(User user);
 
+    public void updateTitleIfEmpty(ChatSession session, String firstQuestion);
+
+    public List<ChatSessionResponseDTO.ChatSessionResponse> getSessionList(Long userId);
 
 }

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
@@ -4,12 +4,14 @@ import callprotector.spring.domain.chat.entity.ChatSession;
 import callprotector.spring.domain.user.entity.User;
 import callprotector.spring.domain.chat.repository.ChatSessionRepository;
 import callprotector.spring.domain.chat.dto.response.ChatSessionResponseDTO;
+import callprotector.spring.global.ai.OpenAiService.OpenAiTitleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 public class ChatSessionServiceImpl implements ChatSessionService{
 
     private final ChatSessionRepository chatSessionRepository;
+    private final OpenAiTitleService openAiTitleService;
 
 
     @Override
@@ -42,7 +45,30 @@ public class ChatSessionServiceImpl implements ChatSessionService{
         return ChatSessionResponseDTO.ChatSessionResponse.builder()
                 .sessionId(saved.getId())
                 .startTime(saved.getStartTime().toString())
+                .title(saved.getTitle()) // title 추가
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateTitleIfEmpty(ChatSession session, String firstQuestion) {
+        if (session.getTitle() == null || session.getTitle().isBlank()) {
+            String generatedTitle = openAiTitleService.generateTitle(firstQuestion);
+            session.setTitle(generatedTitle);
+            chatSessionRepository.save(session);
+        }
+
+    }
+
+    @Override
+    public List<ChatSessionResponseDTO.ChatSessionResponse> getSessionList(Long userId) {
+        return chatSessionRepository.findByUserIdOrderByStartTimeDesc(userId).stream()
+                .map(session -> ChatSessionResponseDTO.ChatSessionResponse.builder()
+                        .sessionId(session.getId())
+                        .title(session.getTitle())
+                        .startTime(session.getStartTime().toString())
+                        .build())
+                .toList();
     }
 
 }

--- a/src/main/java/callprotector/spring/global/ai/OpenAiService/OpenAiTitleService.java
+++ b/src/main/java/callprotector/spring/global/ai/OpenAiService/OpenAiTitleService.java
@@ -1,0 +1,5 @@
+package callprotector.spring.global.ai.OpenAiService;
+
+public interface OpenAiTitleService {
+    String generateTitle(String question);
+}

--- a/src/main/java/callprotector/spring/global/ai/OpenAiService/OpenAiTitleServiceImpl.java
+++ b/src/main/java/callprotector/spring/global/ai/OpenAiService/OpenAiTitleServiceImpl.java
@@ -1,0 +1,55 @@
+package callprotector.spring.global.ai.OpenAiService;
+
+import callprotector.spring.global.config.OpenAiConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class OpenAiTitleServiceImpl implements OpenAiTitleService {
+
+    private final RestTemplate restTemplate;
+    private final HttpHeaders openAiHeaders;
+    private final OpenAiConfig openAiConfig;
+
+    @Override
+    public String generateTitle(String question) {
+        List<Map<String, String>> messages = List.of(
+                Map.of("role", "system", "content", "너는 제목 생성 전문가야. 질문을 간결히 요약해 6~8자의 짧은 제목으로 만들고, 불필요한 설명은 하지 마."),
+                Map.of("role", "user", "content", buildPrompt(question))
+        );
+
+        Map<String, Object> requestBody = Map.of(
+                "model", openAiConfig.getModel(),
+                "messages", messages,
+                "temperature", 0.3
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, openAiHeaders);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "https://api.openai.com/v1/chat/completions", entity, Map.class
+        );
+
+        Map<String, Object> choice = ((List<Map<String, Object>>) response.getBody().get("choices")).get(0);
+        Map<String, String> message = (Map<String, String>) choice.get("message");
+
+        return message.get("content").trim();
+    }
+
+    private String buildPrompt(String question) {
+        return String.format("""
+            다음 질문을 기반으로 6~10자의 짧은 제목을 생성하세요.
+            질문: %s
+            
+            출력은 제목만 반환하세요. 불필요한 설명 없이 제목만 출력.
+        """, question);
+    }
+}

--- a/src/main/resources/static/chatstream.html
+++ b/src/main/resources/static/chatstream.html
@@ -79,23 +79,32 @@
             eventSource.onmessage = (event) => {
                 const chunk = event.data;
 
+                // 1️⃣ 스트리밍 종료 처리
                 if (chunk === "[END]") {
                     try {
+                        buffer = buffer.trim(); // ✅ 끝부분 공백 제거
                         const jsonStart = buffer.indexOf("{");
                         const jsonEnd = buffer.lastIndexOf("}") + 1;
-                        const jsonString = buffer.substring(jsonStart, jsonEnd);
-                        const parsed = JSON.parse(jsonString);
+                        const jsonString = buffer.substring(jsonStart, jsonEnd).trim(); // ✅ 안전하게 추출
+
+                        console.log("📦 최종 파싱 대상 JSON:", jsonString);
+
+                        // ✅ JSON 검증: } 이후 문자 제거
+                        const cleanedJson = jsonString.replace(/}\s*$/, "}");
+
+
+                        const parsed = JSON.parse(cleanedJson); // ✅ JSON만 파싱
 
                         responseDiv.innerHTML = `
-                            <p><strong>💬 답변:</strong><br>${parsed.answer}</p>
-                            <p><strong>📚 출처:</strong></p>
-                            <ul  style="margin-top:5px; margin-bottom:5px;">
-                                ${parsed.sourcePages.map(sp => `
-                                    <li>📌 유형: ${sp["유형"]}<br>
-                                    ⚖ 관련 법률: ${sp["관련 법률"] || sp["관련법률"] || "없음"}</li>
-                                `).join("")}
-                            </ul>
-                        `;
+                <p><strong>💬 답변:</strong><br>${parsed.answer}</p>
+                <p><strong>📚 출처:</strong></p>
+                <ul style="margin-top:5px; margin-bottom:5px;">
+                    ${parsed.sourcePages.map(sp => `
+                        <li>📌 유형: ${sp["유형"]}<br>
+                        ⚖ 관련 법률: ${sp["관련 법률"] || sp["관련법률"] || "없음"}</li>
+                    `).join("")}
+                </ul>
+            `;
                     } catch (e) {
                         console.error("JSON 파싱 오류:", e);
                         responseDiv.innerHTML = "⚠️ 응답 파싱 중 오류 발생";
@@ -107,8 +116,16 @@
                     return;
                 }
 
-                buffer += chunk;
+                // 2️⃣ [JSON] 프리픽스가 있는 데이터만 파싱용 buffer에 추가
+                if (chunk.startsWith("[JSON]")) {
+                    buffer = chunk.replace("[JSON]", "").trim(); // ✅ JSON 데이터만 저장
+                    console.log("🔎 [JSON] 수신 데이터:", buffer);
+                } else {
+                    // 3️⃣ 나머지 데이터는 실시간 UI 표시용 (원하면 표시 로직 추가 가능)
+                    console.log("실시간 토큰:", chunk);
+                }
             };
+
 
             eventSource.onerror = () => {
                 console.log("⛔ SSE 연결 종료");

--- a/src/main/resources/static/chatstream.html
+++ b/src/main/resources/static/chatstream.html
@@ -96,15 +96,20 @@
                         const parsed = JSON.parse(cleanedJson); // ✅ JSON만 파싱
 
                         responseDiv.innerHTML = `
-                <p><strong>💬 답변:</strong><br>${parsed.answer}</p>
-                <p><strong>📚 출처:</strong></p>
-                <ul style="margin-top:5px; margin-bottom:5px;">
-                    ${parsed.sourcePages.map(sp => `
-                        <li>📌 유형: ${sp["유형"]}<br>
-                        ⚖ 관련 법률: ${sp["관련 법률"] || sp["관련법률"] || "없음"}</li>
-                    `).join("")}
-                </ul>
-            `;
+                            <p style="margin-bottom: 8px;"><strong>💬 답변:</strong><br>${parsed.answer}</p>
+                            <p style="margin-bottom: 4px;"><strong>📚 출처:</strong></p>
+                            <ul style="margin: 0; padding: 0; list-style-type: none;">
+                                ${parsed.sourcePages.map(sp => `
+                                    <li style="margin-bottom: 4px;">
+                                        <div style="display: flex; flex-direction: column; gap: 2px; align-items: flex-start;">
+                                            <span>📌 <strong>유형:</strong> ${sp["유형"]}</span>
+                                            <span>⚖ <strong>관련 법률:</strong> ${sp["관련 법률"] || sp["관련법률"] || "없음"}</span>
+                                        </div>
+                                    </li>
+                                `).join("")}
+                            </ul>
+                        `;
+
                     } catch (e) {
                         console.error("JSON 파싱 오류:", e);
                         responseDiv.innerHTML = "⚠️ 응답 파싱 중 오류 발생";


### PR DESCRIPTION
## 📌 작업 내용
- 일반 채팅 API 기능 구현 완료 했습니다.

## 📝 변경 사항
- [x]  DB에 저장되는 최종 JSON 공백문제 해결
- [x] 유형, 관련법률 시작되는 세로선 맞춤
- [x] fast-api에서 json값으로 받은 sourcePages 조회 시, 리스트로 반환하도록 개선
- [x] 세션의 첫 질문에 대한 내용에 맞게 Open-AI가 title 자동 생성 + 세션 목록 조회 API 구현

## 🔗 관련 이슈
- closes #이슈번호

## 📸 스크린샷 (선택)
<img width="1900" height="994" alt="image" src="https://github.com/user-attachments/assets/2f67e88b-0168-46c2-8602-b8c7b41fd46c" />
<img width="1249" height="668" alt="image" src="https://github.com/user-attachments/assets/11f29be9-0449-4768-9204-45e46978006d" />
<img width="1897" height="1350" alt="image" src="https://github.com/user-attachments/assets/78d6e632-eb2d-400e-b615-05c888283bb4" />
<img width="1900" height="1351" alt="image" src="https://github.com/user-attachments/assets/00f6e3e7-5b16-445c-8e84-43ab0efa3052" />

