### PR TITLE
♻️ Refactor: 상담 요약 관련 CallSession 필드 리팩토링

### DIFF
--- a/src/main/java/callprotector/spring/domain/callsession/controller/CallSessionController.java
+++ b/src/main/java/callprotector/spring/domain/callsession/controller/CallSessionController.java
@@ -79,7 +79,7 @@ public class CallSessionController {
 
     @Operation(
             summary = "AI 상담 요약 생성 API - OpenAI GPT",
-            description = "CallSession ID를 기반으로 고객과 상담원의 통화 내용을 요약하여 CallSession의 summary 필드에 저장합니다."
+            description = "CallSession ID를 기반으로 고객과 상담원의 통화 내용을 요약하여 CallSession의 summary_simple 필드에 저장합니다."
     )
     @PostMapping("/{callSessionId}/summary/simple")
     public ApiResponse<CallSessionResponseDTO.CallSessionSummaryResponseDTO> generateSummaryOpenAi(
@@ -92,7 +92,7 @@ public class CallSessionController {
 
     @Operation(
         summary = "AI 상담 요약 생성 API - Gemini 2.5 flash",
-        description = "CallSession ID를 기반으로 고객과 상담원의 통화 내용을 요약하여 CallSession의 summary_gemini 필드에 저장합니다."
+        description = "CallSession ID를 기반으로 고객과 상담원의 통화 내용을 요약하여 CallSession의 summary_detailed 필드에 저장합니다."
     )
     @PostMapping("/{callSessionId}/summary/detailed")
     public ApiResponse<CallSessionResponseDTO.CallSessionSummaryResponseDTO> generateSummaryGemini(

--- a/src/main/java/callprotector/spring/domain/callsession/entity/CallSession.java
+++ b/src/main/java/callprotector/spring/domain/callsession/entity/CallSession.java
@@ -25,7 +25,7 @@ public class CallSession extends BaseEntity {
     @Column(nullable = false, unique = true, length = 20)
     private String callSessionCode;
 
-    @ManyToOne(fetch = FetchType.LAZY) // 지연로딩
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="user_id")
     private User user;
 
@@ -45,19 +45,20 @@ public class CallSession extends BaseEntity {
     @Builder.Default
     private Integer totalAbuseCnt = DEFAULT_ABUSE_COUNT;
 
-    @Column(name = "twilio_call_sid", length = 34) // CA로 시작하는 34자리 문자열
+    // CA로 시작하는 34자리 문자열
+    @Column(name = "twilio_call_sid", length = 34)
     private String twilioCallSid;
 
     // 상담 요약
-    @Column(length = 2000)
-    private String summary;
+    @Column(name= "summary_simple",length = 2000)
+    private String summarySimple;
+
+    @Column(name= "summary_detailed", length = 2000)
+    private String summaryDetailed;
 
     private Boolean summaryGenerated;
 
     private LocalDateTime summaryGeneratedAt;
-
-    @Column(name= "summary_gemini", length = 2000)
-    private String summaryGemini;
 
     public void updateAbuseCnt() {
         this.totalAbuseCnt = (this.totalAbuseCnt == null ? 0 : this.totalAbuseCnt) + 1;
@@ -71,12 +72,12 @@ public class CallSession extends BaseEntity {
         this.abuseTag = Boolean.TRUE;
     }
 
-    public void updateSummaryGemini(String summaryGemini) {
-        this.summaryGemini = summaryGemini;
+    public void updateSummarySimple(String summarySimple) {
+        this.summarySimple = summarySimple;
     }
 
-    public void updateSummary(String summary) {
-        this.summary = summary;
+    public void updateSummaryDetailed(String summaryDetailed) {
+        this.summaryDetailed = summaryDetailed;
     }
 
     public void updateSummaryGenerated(Boolean summaryGenerated) {

--- a/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
@@ -145,7 +145,7 @@ public class CallSessionServiceImpl implements CallSessionService {
 
         // aiSummary - Gemini
         // TODO : AI 요약 구현 방식에 따라 변경 필요
-        String aiSummary = callSession.getSummaryGemini();
+        String aiSummary = callSession.getSummaryDetailed();
         return CallSessionResponseDTO.CallSessionDetailResponseDTO.builder()
             .sessionInfo(sessionInfoDTO)
             .scriptHistory(sessionScriptDTO)
@@ -261,9 +261,9 @@ public class CallSessionServiceImpl implements CallSessionService {
         CallSession session = findCallSessionByIdAndUserId(callSessionId, userId);
 
 
-        if (session.getSummary() != null && !session.getSummary().isBlank()) {
+        if (session.getSummarySimple() != null && !session.getSummarySimple().isBlank()) {
             log.info("✅ 기존 요약 반환 - CallSession ID: {}", callSessionId);
-            return session.getSummary();
+            return session.getSummarySimple();
         }
 
         try {
@@ -297,7 +297,7 @@ public class CallSessionServiceImpl implements CallSessionService {
             String summary = openAiSummaryService.summarize(fullConversation);
             log.info("✅ 요약 생성 완료 - CallSession ID: {}", callSessionId);
 
-            session.updateSummary(summary);
+            session.updateSummarySimple(summary);
             session.updateSummaryGenerated(true);
             session.updateSummaryGeneratedAt(LocalDateTime.now());
             callSessionRepository.save(session);
@@ -326,9 +326,9 @@ public class CallSessionServiceImpl implements CallSessionService {
         CallSession session = findCallSessionByIdAndUserId(callSessionId, userId);
 
         // 중복 생성 방지
-        if (session.getSummaryGemini() != null && !session.getSummaryGemini().isBlank()) {
+        if (session.getSummaryDetailed() != null && !session.getSummaryDetailed().isBlank()) {
             log.info("CallSession (ID: {})에 이미 요약 완료. Gemini api 호출 없이 기존 요약 내용 반환", callSessionId);
-            return session.getSummaryGemini();
+            return session.getSummaryDetailed();
         }
 
         String summaryText;
@@ -361,7 +361,7 @@ public class CallSessionServiceImpl implements CallSessionService {
             summaryText = geminiService.summarizeCallScript(fullConversation);
             log.info("CallSession (ID: {}) 요약 생성 완료.", callSessionId);
 
-            session.updateSummaryGemini(summaryText);
+            session.updateSummaryDetailed(summaryText);
             log.info("summaryGemini: {}", summaryText);
             callSessionRepository.save(session);
             return summaryText;


### PR DESCRIPTION
## 📌 작업 내용
- AI 상담 요약 관련 DB의 필드명을 변경 및 관련 로직을 수정하였습니다.

## 📝 변경 사항
- [x] CallSession 내 summary 필드 summary_simple로 변경
- [x] CallSession 내 summary_gemini 필드 summary_detailed로 변경
- [x] 필드명 변경에 따른 CallSession 관련 service, controller 수정

## 🔗 관련 이슈
- closes #117 

## 📸 스크린샷 (선택)
<img width="1223" height="449" alt="summary" src="https://github.com/user-attachments/assets/5246304a-fb55-4248-81a3-a2d1d6ecb2c0" />
