### PR TITLE
✨ Feat: FastAPI 서버 배포에 따른 연동 설정 추가

### DIFF
--- a/src/main/java/callprotector/spring/domain/abuse/controller/AbuseController.java
+++ b/src/main/java/callprotector/spring/domain/abuse/controller/AbuseController.java
@@ -1,6 +1,5 @@
 package callprotector.spring.domain.abuse.controller;
 
-
 import callprotector.spring.global.apiPayload.ApiResponse;
 import callprotector.spring.domain.abuse.service.AbuseService;
 import callprotector.spring.domain.abuse.dto.request.AbuseRequestDTO;
@@ -8,31 +7,20 @@ import callprotector.spring.domain.abuse.dto.response.AbuseResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController // 해당 클래스 Controller로 지정
-// @Controller + @ReseponseBody 합친 것으로, 컨트롤러 내 모든 메서드가 반환 시 객체를 자동으로 JSON 형식으로 변환
+@RestController
 @RequestMapping("/abuse")
-@RequiredArgsConstructor // private final AbuseService abuseService; 적었다면, Service 생성자 자동 생성 후 주입해줌
-// final "자바에서 한 번만 할당할 수 있다" (한 번 값이 정해지면 다시 바꿀 수 X)
+@RequiredArgsConstructor
 public class AbuseController {
 
-    private final AbuseService abuseService; // -> 의존성 주입 시, 주입된 객체가 바뀌지 않도록 보장
+    private final AbuseService abuseService;
 
-    // 함수에 응답 형식 DTO, 파라미터에 요청 형식 DTO (클라이언트가 요청 보내니까 파라미터, 처리결과는 응답이니가 응답 DTO)
     @Operation(summary = "욕설 필터링 API", description = "욕설 필터링 API입니다.")
-    @GetMapping("/abuse-filter")
-    public ApiResponse<AbuseResponseDTO.AbuseFilterDTO> filterAbuse(@RequestBody AbuseRequestDTO.AbuseFilterDTO request) {
-        AbuseResponseDTO.AbuseFilterDTO result = abuseService.analyzeText(request.getText());
-        return ApiResponse.onSuccess(result);
+    @PostMapping("/filter")
+    public ApiResponse<AbuseResponseDTO.AbuseFilterDTO> filterAbuse(
+            @RequestBody AbuseRequestDTO.AbuseFilterDTO request) {
+        return ApiResponse.onSuccess(abuseService.analyzeText(request.getText()));
     }
-
-
-
-
-
 
 }

--- a/src/main/java/callprotector/spring/global/client/FastClient.java
+++ b/src/main/java/callprotector/spring/global/client/FastClient.java
@@ -3,6 +3,7 @@ package callprotector.spring.global.client;
 import callprotector.spring.domain.abuse.dto.response.AbuseResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -15,12 +16,12 @@ import java.util.Map;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-
 public class FastClient {
 
     private final RestTemplate restTemplate;
 
-    private static final String FASTAPI_URL = "http://localhost:8080/filter-abuse";
+    @Value("${fastapi.url}")
+    private String fastApiUrl;
 
     public AbuseResponseDTO.AbuseFilterDTO sendTextToFastAPI(String text) {
         HttpHeaders headers = new HttpHeaders();
@@ -29,22 +30,27 @@ public class FastClient {
         Map<String, String> requestBody = Map.of("text", text);
         HttpEntity<Map<String, String>> entity = new HttpEntity<>(requestBody, headers);
 
-        ResponseEntity<AbuseResponseDTO.AbuseFilterDTO> response = restTemplate.postForEntity(
-                FASTAPI_URL,
-                entity,
-                AbuseResponseDTO.AbuseFilterDTO.class
-        );
+        try {
+            ResponseEntity<AbuseResponseDTO.AbuseFilterDTO> response = restTemplate.postForEntity(
+                    fastApiUrl,
+                    entity,
+                    AbuseResponseDTO.AbuseFilterDTO.class
+            );
 
-        AbuseResponseDTO.AbuseFilterDTO result = response.getBody();
-        if (result == null) {
-            log.warn("⚠️ FastAPI 응답이 null입니다.");
-            return null;
+            AbuseResponseDTO.AbuseFilterDTO result = response.getBody();
+            if (result == null) {
+                log.warn("⚠️ FastAPI 응답이 null입니다.");
+                return new AbuseResponseDTO.AbuseFilterDTO(false, false, "분석 실패(null)");
+            }
+
+            log.info("🚨 욕설 분석 결과: abuse={}, detected={}, type={}",
+                    result.isAbuse(), result.isDetected(), result.getType());
+
+            return result;
+
+        } catch (Exception e) {
+            log.error("🔥 FastAPI 호출 실패: {}", e.getMessage(), e);
+            return new AbuseResponseDTO.AbuseFilterDTO(false, false, "분석 실패");
         }
-        log.info("🚨 욕설 분석 결과: abuse={}, detected={}, type={}",
-                result.isAbuse(), result.isDetected(), result.getType());
-
-        return result;
-
     }
-
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -60,3 +60,6 @@ elasticsearch:
   host: localhost
   port: 9200
   enabled: false
+
+fastapi:
+  url: http://localhost:8000/api/abuse/filter

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -60,3 +60,6 @@ elasticsearch:
   host: localhost
   port: 9200
   enabled: false
+
+fastapi:
+  url: http://abusefilter:8080/api/abuse/filter


### PR DESCRIPTION
## 📌 작업 내용
- FastAPI 서버 배포에 따른 SpringBoot 연동 작업을 진행했습니다.

## 📝 변경 사항
- [x] 환경별 yml 내 FastAPI URL 추가
- [x] FastClient 내 FastAPI URL 설정 외부화 및 호출 실패 대응 로직 추가
- [x] AbuseController HTTP Method 및 Endpoint 수정 (@GetMapping("/abuse-filter") → @PostMapping("/filter")) 

## 🔗 관련 이슈
- closes #124 

## 📸 스크린샷 (선택)
<img width="1081" height="368" alt="필터링" src="https://github.com/user-attachments/assets/2bd3af93-4f8c-47a6-bfe1-017abf75f0ed" />
