### PR TITLE
✨ Feat: 로그인 API 응답값 수정

### DIFF
--- a/src/main/java/callprotector/spring/domain/user/controller/AuthController.java
+++ b/src/main/java/callprotector/spring/domain/user/controller/AuthController.java
@@ -35,8 +35,6 @@ public class AuthController {
         return ApiResponse.onSuccess("이메일 인증이 완료되었습니다.");
     }
 
-
-
     // 회원가입 API
     @Operation(summary = "회원가입 API", description = "이름, 메일, 전화번호, 비밀번호를 넣어주세요. 비밀번호는 영문, 숫자, 특수문자 포함 8~20자리입니다.")
     @PostMapping("/signup")
@@ -54,14 +52,4 @@ public class AuthController {
         UserResponseDTO.LoginDTO result = userService.login(loginDTO);
         return ApiResponse.onSuccess(result);
     }
-
-
-
-
-
-
-
-
-
-
 }

--- a/src/main/java/callprotector/spring/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/callprotector/spring/domain/user/dto/response/UserResponseDTO.java
@@ -22,6 +22,7 @@ public class UserResponseDTO {
     public static class LoginDTO{
         String token;
         Long id;
+        String name;
     }
 
 

--- a/src/main/java/callprotector/spring/domain/user/service/UserService.java
+++ b/src/main/java/callprotector/spring/domain/user/service/UserService.java
@@ -16,4 +16,5 @@ public interface UserService {
 
     public User getUserById(Long id);
 
+    public User getUserByEmail(String email);
 }

--- a/src/main/java/callprotector/spring/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/user/service/UserServiceImpl.java
@@ -1,10 +1,12 @@
 package callprotector.spring.domain.user.service;
 
+import callprotector.spring.global.apiPayload.exception.handler.PasswordMismatchException;
 import callprotector.spring.global.apiPayload.exception.handler.UserNotFoundException;
 import callprotector.spring.domain.user.entity.User;
 import callprotector.spring.domain.user.entity.VerificationToken;
 import callprotector.spring.domain.user.repository.UserRepository;
 import callprotector.spring.domain.user.repository.VerificationTokenRepository;
+import callprotector.spring.global.apiPayload.exception.handler.UserValidationException;
 import callprotector.spring.global.security.TokenProvider;
 import callprotector.spring.global.util.PasswordValidator;
 import callprotector.spring.domain.user.dto.request.UserRequestDTO;
@@ -103,15 +105,16 @@ public class UserServiceImpl implements UserService{
     @Override
     @Transactional(readOnly = true)
     public UserResponseDTO.LoginDTO login(UserRequestDTO.LoginDTO dto) {
-        final Optional<User> user = userRepository.findByEmail(dto.getEmail());
+        User user = getUserByEmail(dto.getEmail());
 
-        if (user.isEmpty() || !passwordEncoder.matches(dto.getPassword(), user.get().getPassword())) {
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new PasswordMismatchException();
         }
 
         return UserResponseDTO.LoginDTO.builder()
-                .token(tokenProvider.create(user.get()))
-                .id(user.get().getId())
+                .token(tokenProvider.create(user))
+                .id(user.getId())
+                .name(user.getName())
                 .build();
     }
 
@@ -119,5 +122,11 @@ public class UserServiceImpl implements UserService{
     @Transactional(readOnly = true)
     public User getUserById(Long id) {
         return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(UserValidationException::new);
     }
 }

--- a/src/main/java/callprotector/spring/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/callprotector/spring/global/apiPayload/code/status/ErrorStatus.java
@@ -18,6 +18,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // User 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041", "사용자가 없습니다."),
+    USER_VALIDATION_ERROR(HttpStatus.UNAUTHORIZED, "USER4011", "등록되지 않은 이메일입니다."),
+    USER_PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "4012", "비밀번호가 일치하지 않습니다."),
 
     // Call Session 관련 에러
     CALL_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CALLSESSION4041", "call session이 존재하지 않습니다."),

--- a/src/main/java/callprotector/spring/global/apiPayload/exception/handler/PasswordMismatchException.java
+++ b/src/main/java/callprotector/spring/global/apiPayload/exception/handler/PasswordMismatchException.java
@@ -1,0 +1,10 @@
+package callprotector.spring.global.apiPayload.exception.handler;
+
+import callprotector.spring.global.apiPayload.code.status.ErrorStatus;
+import callprotector.spring.global.apiPayload.exception.GeneralException;
+
+public class PasswordMismatchException extends GeneralException {
+	public PasswordMismatchException() {
+		super(ErrorStatus.USER_PASSWORD_MISMATCH);
+	}
+}

--- a/src/main/java/callprotector/spring/global/apiPayload/exception/handler/UserValidationException.java
+++ b/src/main/java/callprotector/spring/global/apiPayload/exception/handler/UserValidationException.java
@@ -1,0 +1,10 @@
+package callprotector.spring.global.apiPayload.exception.handler;
+
+import callprotector.spring.global.apiPayload.code.status.ErrorStatus;
+import callprotector.spring.global.apiPayload.exception.GeneralException;
+
+public class UserValidationException extends GeneralException {
+	public UserValidationException() {
+		super(ErrorStatus.USER_VALIDATION_ERROR);
+	}
+}


### PR DESCRIPTION
## 📌 작업 내용
- 로그인 api 의 응답값에 유저 이름 속성을 추가합니다.
- 로그인 시, 미등록 이메일과 비밀번호 불일치에 대한 커스텀 예외 처리를 진행합니다.

## 📝 변경 사항
- [x] 유저 이름 속성 추가
- [x] 로그인 시 커스텀 예외 처리 추가

## 🔗 관련 이슈
- closes #130

## 📸 스크린샷 (선택)
| 성공 | 회원가입되지 않은 이메일로 로그인할 경우 | 비밀번호가 잘못된 경우 |
|---|---|---|
| <img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/3ea16f43-8d8e-4aeb-bcd8-252ee9417407" /> | <img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/79be2ff2-f69d-4107-8fac-89fbfc936b37" /> | <img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/a1bfa2aa-3c4a-423a-a1bb-c72377ddb23c" /> |


