### PR TITLE
✨ Feat: ElasticSerach 컨테이너 배포 및 Spring 연동 설정 적용

### DIFF
--- a/src/main/java/callprotector/spring/global/config/ElasticsearchConfig.java
+++ b/src/main/java/callprotector/spring/global/config/ElasticsearchConfig.java
@@ -1,5 +1,6 @@
 package callprotector.spring.global.config;
 
+import lombok.Setter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
@@ -16,8 +17,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.elasticsearch.client.RestClient;
 
-// ElasticSearch 임시 비활성화용 어노테이션 추가
-@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true") 
+@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true")
 @Configuration
 @EnableConfigurationProperties(ElasticsearchConfig.ElasticsearchProperties.class)
 @RequiredArgsConstructor
@@ -43,10 +43,12 @@ public class ElasticsearchConfig {
     }
 
     @Getter
+    @Setter
     @ConfigurationProperties(prefix = "elasticsearch")
     public static class ElasticsearchProperties {
         private String host;
         private int port;
+        private boolean enabled;
     }
 }
 

--- a/src/main/java/callprotector/spring/global/elasticsearch/CallSttLogIndexConfig.java
+++ b/src/main/java/callprotector/spring/global/elasticsearch/CallSttLogIndexConfig.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-// 임시 비활성화용 어노테이션 추가 
 @ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true")
 @Slf4j
 @Component

--- a/src/main/java/callprotector/spring/global/elasticsearch/CallSttLogIndexer.java
+++ b/src/main/java/callprotector/spring/global/elasticsearch/CallSttLogIndexer.java
@@ -25,10 +25,20 @@ public class CallSttLogIndexer {
     private final CallSttLogRepository callSttLogRepository;
     private final ElasticsearchClient esClient;
 
-    @EventListener(ApplicationReadyEvent.class) // 애플리케이션 시작 시 실행
+    @EventListener(ApplicationReadyEvent.class)
     public void reindexAllLogs() throws IOException {
-        List<CallSttLog> mongoLogs = callSttLogRepository.findAll();
+        // 1. 이미 인덱스가 존재하면 재색인 생략
+        boolean indexExists = esClient.indices()
+                .exists(b -> b.index("call_stt_log"))
+                .value();
 
+        if (indexExists) {
+            log.info("ℹ️ call_stt_log 인덱스가 이미 존재합니다. 재색인 생략");
+            return;
+        }
+
+        // 2. 인덱스 없으면 재색인 진행
+        List<CallSttLog> mongoLogs = callSttLogRepository.findAll();
         log.info("📦 MongoDB에서 불러온 CallSttLog 개수: {}", mongoLogs.size());
 
         List<BulkOperation> operations = mongoLogs.stream()
@@ -36,18 +46,14 @@ public class CallSttLogIndexer {
                         .index(i -> i
                                 .index("call_stt_log")
                                 .document(log)
-                        )))
-                .toList();
+                        ))).toList();
 
         BulkRequest bulkRequest = BulkRequest.of(b -> b.operations(operations));
         BulkResponse response = esClient.bulk(bulkRequest);
 
         if (response.errors()) {
-            log.error("❌ 일부 문서 이관 실패: {}",
-                    response.items().stream()
-                            .filter(item -> item.error() != null)
-                            .toList()
-            );
+            log.error("❌ 일부 문서 이관 실패: {}", response.items().stream()
+                    .filter(item -> item.error() != null).toList());
         } else {
             log.info("🚀 Elasticsearch 재색인 완료: {}건", mongoLogs.size());
         }

--- a/src/main/java/callprotector/spring/global/elasticsearch/CallSttLogIndexer.java
+++ b/src/main/java/callprotector/spring/global/elasticsearch/CallSttLogIndexer.java
@@ -16,7 +16,6 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import java.io.IOException;
 import java.util.List;
 
-// 임시 비활성화용 어노테이션 추가
 @ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true")
 @Slf4j
 @Component

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,7 +59,7 @@ gcp:
 elasticsearch:
   host: localhost
   port: 9200
-  enabled: false
+  enabled: true
 
 fastapi:
   url: http://localhost:8000/api/abuse/filter

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -57,9 +57,9 @@ gcp:
     id: ${GCP_LOCATION_ID}
 
 elasticsearch:
-  host: localhost
+  host: elasticsearch
   port: 9200
-  enabled: false
+  enabled: true
 
 fastapi:
   url: http://abusefilter:8080/api/abuse/filter


### PR DESCRIPTION
## 📌 작업 내용
- ElasticSearch를 Docker 컨테이너로 배포하고, Spring 서버와의 연동을 위한 설정을 추가했습니다.
기존에 임시로 비활성화된 설정을 제거하고, 도커 네트워크를 통한 통신 설정을 적용했습니다.

## 📝 변경 사항
- [x] 기존 임시 비활성화 설정 제거
- [x] callSttLogIndexer 내 인덱스 존재 시 재색인 생략하는 로직 추가
- [x] docker-compose.yml에 Elasticsearch 블록 추가
- [x] Spring 서버 재배포 및 Elasticsearch 연동 확인

## 🔗 관련 이슈
- closes #139 

## 📸 스크린샷 (선택)
<img width="725" height="676" alt="검색" src="https://github.com/user-attachments/assets/ca14a13f-f356-4de3-b2c4-4d0682b4b4b8" />
