### PR TITLE
✨ Feat: 챗봇 폭언 상담 내역 조회 API 구현

### DIFF
--- a/src/main/java/callprotector/spring/domain/abuse/repository/AbuseTypeLogRepository.java
+++ b/src/main/java/callprotector/spring/domain/abuse/repository/AbuseTypeLogRepository.java
@@ -1,13 +1,19 @@
 package callprotector.spring.domain.abuse.repository;
 
-import callprotector.spring.domain.abuse.entity.AbuseLog;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import callprotector.spring.domain.abuse.entity.AbuseType;
 import callprotector.spring.domain.abuse.entity.AbuseTypeLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AbuseTypeLogRepository extends JpaRepository<AbuseTypeLog, Long> {
-    List<AbuseTypeLog> findByAbuseLog(AbuseLog abuseLog);
+    @Query("SELECT atl.abuseType FROM AbuseTypeLog atl " +
+            "JOIN atl.abuseLog al " +
+            "JOIN al.callLog cl " +
+            "WHERE cl.callSession.id = :sessionId")
+    List<AbuseType> findAbuseTypesByCallSessionId(@Param("sessionId") Long sessionId);
 
     boolean existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_VerbalAbuseTrue(Long sessionId);
 

--- a/src/main/java/callprotector/spring/domain/abuse/repository/AbuseTypeLogRepository.java
+++ b/src/main/java/callprotector/spring/domain/abuse/repository/AbuseTypeLogRepository.java
@@ -8,4 +8,10 @@ import java.util.List;
 
 public interface AbuseTypeLogRepository extends JpaRepository<AbuseTypeLog, Long> {
     List<AbuseTypeLog> findByAbuseLog(AbuseLog abuseLog);
+
+    boolean existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_VerbalAbuseTrue(Long sessionId);
+
+    boolean existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_SexualHarassTrue(Long sessionId);
+
+    boolean existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_ThreatTrue(Long sessionId);
 }

--- a/src/main/java/callprotector/spring/domain/callsession/controller/CallSessionController.java
+++ b/src/main/java/callprotector/spring/domain/callsession/controller/CallSessionController.java
@@ -69,7 +69,7 @@ public class CallSessionController {
         );
     }
 
-    @Operation(summary = "callSession 상세 조회", description = "상담 내역 상세 조회 시 callSession을 조회합니다.")
+    @Operation(summary = "callSession 상세 조회 API", description = "상담 내역 상세 조회 시 callSession을 조회합니다.")
     @GetMapping("/{callSessionId}")
     public ApiResponse<CallSessionResponseDTO.CallSessionDetailResponseDTO> getCallSession(
         @PathVariable("callSessionId") Long id,
@@ -78,8 +78,6 @@ public class CallSessionController {
         CallSessionResponseDTO.CallSessionDetailResponseDTO response = callSessionService.getUserCallSessionDetail(id, userId);
         return ApiResponse.onSuccess(response);
     }
-
-
 
     @Operation(
             summary = "AI 상담 요약 생성 API - OpenAI GPT",
@@ -108,7 +106,7 @@ public class CallSessionController {
     }
 
     @Operation(
-        summary = "전화 수락 시 call session 생성",
+        summary = "전화 수락 시 call session 생성 API",
         description = "전화 수락 시 해당 userId로 callsession을 생성하고 세션 정보를 반환합니다."
     )
     @PatchMapping("/user")
@@ -133,4 +131,24 @@ public class CallSessionController {
 
         return ApiResponse.onSuccess(response);
     }
+
+    @Operation(
+            summary = "폭언 상담 내역 조회 API",
+            description = "폭언(욕설, 성희롱, 협박)이 발생한 상담 내역만 조회합니다."
+    )
+    @GetMapping("/abusive")
+    public ApiResponse<CallSessionResponseDTO.AbusiveCallSessionPagingDTO> getAbusiveCallSessions(
+            @UserId Long userId,
+
+            @Parameter(description = "현재 페이지의 기준이 되는 마지막 CallSession ID")
+            @RequestParam(required = false) Long cursorId,
+
+            @Parameter(description = "가져올 데이터 개수 (기본값: 5)")
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        return ApiResponse.onSuccess(
+                callSessionService.getAbusiveCallSessions(userId, cursorId, size)
+        );
+    }
+
 }

--- a/src/main/java/callprotector/spring/domain/callsession/dto/response/CallSessionResponseDTO.java
+++ b/src/main/java/callprotector/spring/domain/callsession/dto/response/CallSessionResponseDTO.java
@@ -95,8 +95,38 @@ public class CallSessionResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class AbusiveCallSessionDTO {
+        private Long id;
+        private String callSessionCode;
+        private LocalDateTime createdAt;
+        private String category;
+
+        public static AbusiveCallSessionDTO fromEntity(CallSession session, String category) {
+            return AbusiveCallSessionDTO.builder()
+                    .id(session.getId())
+                    .callSessionCode(session.getCallSessionCode())
+                    .createdAt(session.getCreatedAt())
+                    .category(category)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class CallSessionPagingDTO {
         private List<CallSessionListDTO> sessions;
+        private Long nextCursorId;
+        private boolean hasNext;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AbusiveCallSessionPagingDTO {
+        private List<AbusiveCallSessionDTO> sessions;
         private Long nextCursorId;
         private boolean hasNext;
     }

--- a/src/main/java/callprotector/spring/domain/callsession/repository/CallSessionRepositoryCustom.java
+++ b/src/main/java/callprotector/spring/domain/callsession/repository/CallSessionRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface CallSessionRepositoryCustom {
 
     List<CallSession> findSessionsByAbuseCategoryAndUserId(String category, Long userId, Long cursorId, int limit, Sort.Direction direction);
     List<CallSession> findByIdsWithOrderAndUserId(List<Long> ids, Sort.Direction direction, Long userId);
+
+    List<CallSession> findAbusiveCallSessions(Long userId, Long cursorId, int limit);
 }

--- a/src/main/java/callprotector/spring/domain/callsession/repository/CallSessionRepositoryImpl.java
+++ b/src/main/java/callprotector/spring/domain/callsession/repository/CallSessionRepositoryImpl.java
@@ -20,6 +20,7 @@ public class CallSessionRepositoryImpl implements CallSessionRepositoryCustom {
     @Override
     public List<CallSession> findFirstPageByUserId(Long userId, String sortBy, int limit, Sort.Direction direction) {
         String jpql = "SELECT c FROM CallSession c WHERE c.user.id = :userId ORDER BY c." + sortBy + " " + direction.name();
+
         return em.createQuery(jpql, CallSession.class)
                 .setParameter("userId", userId)
                 .setMaxResults(limit)
@@ -79,4 +80,26 @@ public class CallSessionRepositoryImpl implements CallSessionRepositoryCustom {
                 .setParameter("userId", userId)
                 .getResultList();
     }
+
+    @Override
+    public List<CallSession> findAbusiveCallSessions(Long userId, Long cursorId, int limit) {
+        String jpql =
+                "SELECT DISTINCT cs FROM CallSession cs " +
+                        "JOIN CallLog cl ON cl.callSession = cs " +
+                        "JOIN AbuseLog al ON al.callLog = cl " +
+                        "WHERE cs.user.id = :userId " +
+                        (cursorId != null ? "AND cs.id < :cursorId " : "") +
+                        "ORDER BY cs.id DESC";
+
+        TypedQuery<CallSession> query = em.createQuery(jpql, CallSession.class)
+                .setParameter("userId", userId)
+                .setMaxResults(limit);
+
+        if (cursorId != null) {
+            query.setParameter("cursorId", cursorId);
+        }
+
+        return query.getResultList();
+    }
+
 }

--- a/src/main/java/callprotector/spring/domain/callsession/service/CallSessionService.java
+++ b/src/main/java/callprotector/spring/domain/callsession/service/CallSessionService.java
@@ -36,4 +36,6 @@ public interface CallSessionService {
     Long createTempSession(Long userId, CallSessionRequestDTO.CallSessionMakeDTO dto);
 
     CallSessionResponseDTO.CallSessionInfoDTO getSessionInfo(Long callSessionId);
- }
+
+    CallSessionResponseDTO.AbusiveCallSessionPagingDTO getAbusiveCallSessions(Long userId, Long cursorId, int size);
+}

--- a/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
@@ -458,6 +458,45 @@ public class CallSessionServiceImpl implements CallSessionService {
         return session;
     }
 
+    @Override
+    public CallSessionResponseDTO.AbusiveCallSessionPagingDTO getAbusiveCallSessions(Long userId, Long cursorId, int size) {
+        List<CallSession> sessions = callSessionRepository.findAbusiveCallSessions(userId, cursorId, size + 1);
+
+        boolean hasNext = sessions.size() > size;
+        Long nextCursorId = hasNext ? sessions.get(size - 1).getId() : null;
+
+        List<CallSessionResponseDTO.AbusiveCallSessionDTO> resultList = sessions.stream()
+                .limit(size)
+                .map(session -> {
+                    String category = resolveAbuseCategory(session.getId());
+                    return CallSessionResponseDTO.AbusiveCallSessionDTO.fromEntity(session, category);
+                })
+                .collect(Collectors.toList());
+
+        return CallSessionResponseDTO.AbusiveCallSessionPagingDTO.builder()
+                .sessions(resultList)
+                .hasNext(hasNext)
+                .nextCursorId(nextCursorId)
+                .build();
+    }
+
+
+    private String resolveAbuseCategory(Long sessionId) {
+        List<String> categories = new ArrayList<>();
+
+        if (abuseTypeLogRepository.existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_VerbalAbuseTrue(sessionId)) {
+            categories.add("욕설");
+        }
+        if (abuseTypeLogRepository.existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_SexualHarassTrue(sessionId)) {
+            categories.add("성희롱");
+        }
+        if (abuseTypeLogRepository.existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_ThreatTrue(sessionId)) {
+            categories.add("협박");
+        }
+
+        return String.join(", ", categories);
+    }
+
     private void validateAbuseCategory(String category) {
         List<String> valid = List.of("verbalAbuse", "sexualHarass", "threat");
         if (!valid.contains(category)) {
@@ -474,7 +513,7 @@ public class CallSessionServiceImpl implements CallSessionService {
                 List<AbuseTypeLog> typeLogs = abuseTypeLogRepository.findByAbuseLog(abuseLog);
                 for (AbuseTypeLog typeLog : typeLogs) {
                     AbuseType type = typeLog.getAbuseType();
-                    if (type.isVerbalAbuse()) return "폭언";
+                    if (type.isVerbalAbuse()) return "욕설";
                     if (type.isSexualHarass()) return "성희롱";
                     if (type.isThreat()) return "협박";
                 }

--- a/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
@@ -505,21 +505,16 @@ public class CallSessionServiceImpl implements CallSessionService {
     }
 
     private String getAbuseCategoryForSession(CallSession session) {
-        List<CallLog> callLogs = callLogRepository.findByCallSession(session);
+        List<AbuseType> types = abuseTypeLogRepository.findAbuseTypesByCallSessionId(session.getId());
 
-        for (CallLog callLog : callLogs) {
-            List<AbuseLog> abuseLogs = abuseLogRepository.findByCallLog(callLog);
-            for (AbuseLog abuseLog : abuseLogs) {
-                List<AbuseTypeLog> typeLogs = abuseTypeLogRepository.findByAbuseLog(abuseLog);
-                for (AbuseTypeLog typeLog : typeLogs) {
-                    AbuseType type = typeLog.getAbuseType();
-                    if (type.isVerbalAbuse()) return "욕설";
-                    if (type.isSexualHarass()) return "성희롱";
-                    if (type.isThreat()) return "협박";
-                }
-            }
+        Set<String> categories = new LinkedHashSet<>();
+        for (AbuseType type : types) {
+            if (type.isVerbalAbuse()) categories.add("욕설");
+            if (type.isSexualHarass()) categories.add("성희롱");
+            if (type.isThreat()) categories.add("협박");
         }
-        return "전체";
+
+        return categories.isEmpty() ? "전체" : String.join(", ", categories);
     }
 
     // 검색어가 포함된 scrpit 일부만 추출하여 반환하는 함수


### PR DESCRIPTION
## 📌 작업 내용
- 챗봇 페이지 내에서 사용될 폭언이 발생한 상담 내역만 불러오는 API를 구현했습니다.

## 📝 변경 사항
- [x] 폭언 상담 내역 조회 서비스 로직 구현
- [x] 폭언 상담 내역 조회 전용 응답 DTO 및 Repository 쿼리 메서드 작성

## 🔗 관련 이슈
- closes #145 

## 📸 스크린샷 (선택)
<img width="851" height="605" alt="폭언 상담 내역1" src="https://github.com/user-attachments/assets/5eec9620-0b8e-41b3-ba50-a952c45e8749" />
<img width="854" height="533" alt="폭언 상담 내역2" src="https://github.com/user-attachments/assets/3aa9c3f9-b1bd-4269-9318-472c100cec97" />