### PR TITLE
✨ Feat: Chatbot 배포 및 WebClient 호출 로직 공통화

### DIFF
--- a/src/main/java/callprotector/spring/domain/callchat/controller/CallChatStreamController.java
+++ b/src/main/java/callprotector/spring/domain/callchat/controller/CallChatStreamController.java
@@ -5,6 +5,7 @@ import callprotector.spring.domain.callsttlog.service.CallSttLogService;
 import callprotector.spring.domain.callchat.entity.CallChatSession;
 import callprotector.spring.domain.callchat.service.CallChatLogService;
 import callprotector.spring.domain.callchat.service.CallChatSessionService;
+import callprotector.spring.global.client.ChatbotClient;
 import callprotector.spring.global.security.TokenProvider;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
@@ -30,7 +30,8 @@ import java.util.Map;
 @Tag(name = "CallChatStream", description = "상담별 채팅 질문 전송 관련 API")
 public class CallChatStreamController {
 
-    private final WebClient webClient = WebClient.create("http://localhost:8000"); // FastAPI
+    private final ChatbotClient chatbotClient;
+
     private final CallChatLogService callChatLogService;
     private final CallChatSessionService callChatSessionService;
     private final TokenProvider tokenProvider;
@@ -38,8 +39,10 @@ public class CallChatStreamController {
     // 08/13 추가: STT 로그 조회용
     private final CallSttLogService callSttLogService;
 
-
-    @Operation(summary = "상담별 채팅 질문 전송 API", description ="상담원이 입력한 법률 질문을, 문맥을 유지하고 있는 챗봇에게 전송하고 응답을 받아옵니다.")
+    @Operation(
+            summary = "상담별 채팅 질문 전송 API",
+            description ="상담원이 입력한 법률 질문을, 문맥을 유지하고 있는 챗봇에게 전송하고 응답을 받아옵니다."
+    )
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> streamCallChat(
             @Parameter(description = "대화가 기록될 CallChatSession ID", required = true)
@@ -81,23 +84,17 @@ public class CallChatStreamController {
             contextScripts = scripts;
         }
 
-
-
         StringBuilder jsonBuffer = new StringBuilder();
 
         // 3) FastAPI 호출
-        return webClient.post()
-                .uri("ai/callchat/stream")
-                .contentType(MediaType.APPLICATION_JSON)                 // 추가
-                .accept(MediaType.TEXT_EVENT_STREAM)                     // 추가
-                // ★★★  08/13 수정(해야됨묘ㅋ) ~
-                .bodyValue(Map.of(
-                        "session_id", callChatSessionId,   // 백엔드 메모리 키로 쓰고 싶으면 이 값 활용
-                        "question", question,
-                        "context_scripts", contextScripts
-                ))
-                .retrieve()
-                .bodyToFlux(String.class)
+        return chatbotClient.sendChatRequest(
+                        "/ai/callchat/stream",
+                        Map.of(
+                                "session_id", callChatSessionId,   // 백엔드 메모리 키로 쓰고 싶으면 이 값 활용
+                                "question", question,
+                                "context_scripts", contextScripts
+                        )
+                )
                 .map(raw -> {                                            // data: 조건부 제거
                     String s = raw == null ? "" : raw.trim();
                     if (s.startsWith("data:")) s = s.substring(5).trim();

--- a/src/main/java/callprotector/spring/domain/callchat/service/CallChatbotServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callchat/service/CallChatbotServiceImpl.java
@@ -4,12 +4,11 @@ import callprotector.spring.domain.callsession.service.CallSessionService;
 import callprotector.spring.domain.callsttlog.entity.CallSttLog;
 import callprotector.spring.domain.callsttlog.service.CallSttLogService;
 import callprotector.spring.domain.user.service.UserService;
+import callprotector.spring.global.client.ChatbotClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -20,7 +19,8 @@ import java.util.Map;
 @Slf4j
 public class CallChatbotServiceImpl implements CallChatbotService {
 
-    private final WebClient.Builder webClientBuilder;
+    private final ChatbotClient chatbotClient;
+
     private final CallSttLogService callSttLogService;
 
     // 저장을 위한 추가 주입
@@ -41,6 +41,7 @@ public class CallChatbotServiceImpl implements CallChatbotService {
 
         // MongoDB 에서 script 조회
         List<CallSttLog> logs = callSttLogService.getAllBySessionId(sessionId);
+
         // STT 스크립트 -> FastAPI 요청 페이로드 구성
         List<Map<String, String>> scripts = logs.stream()
                 .map(log -> Map.of(
@@ -52,19 +53,14 @@ public class CallChatbotServiceImpl implements CallChatbotService {
         // [JSON] 청크 버퍼
         StringBuilder jsonBuffer = new StringBuilder();
 
-        return webClientBuilder.build()
-                .post()
-                .uri("http://localhost:8000/ai/callsession/analyze")  // FastAPI 주소
-                .contentType(MediaType.APPLICATION_JSON)
-                // ★★★ 이 부분 수정해야되나?
-                .bodyValue(Map.of(
-                        "sessionId", sessionId,
-                        "userId", userId,
-                        "scripts", scripts
-                ))
-                .accept(MediaType.TEXT_EVENT_STREAM)
-                .retrieve()
-                .bodyToFlux(String.class)
+        return chatbotClient.sendChatRequest(
+                        "/ai/callsession/analyze",
+                        Map.of(
+                                "sessionId", sessionId,
+                                "userId", userId,
+                                "scripts", scripts
+                        )
+                )
                 // 1) "data:" 접두사는 있을 수도/없을 수도 → 조건부 제거
                 .map(raw -> {
                     String s = raw == null ? "" : raw.trim();

--- a/src/main/java/callprotector/spring/domain/chat/controller/ChatStreamController.java
+++ b/src/main/java/callprotector/spring/domain/chat/controller/ChatStreamController.java
@@ -3,6 +3,7 @@ package callprotector.spring.domain.chat.controller;
 import callprotector.spring.domain.chat.entity.ChatSession;
 import callprotector.spring.domain.chat.service.ChatLogService;
 import callprotector.spring.domain.chat.service.ChatSessionService;
+import callprotector.spring.global.client.ChatbotClient;
 import callprotector.spring.global.security.TokenProvider;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
@@ -29,12 +29,16 @@ import java.util.Map;
 @Tag(name = "ChatStream", description = "일반 채팅 질문 전송 관련 API")
 public class ChatStreamController {
 
-    private final WebClient webClient = WebClient.create("http://localhost:8000"); // FastAPI URL
+    private final ChatbotClient chatbotClient;
+
     private final ChatLogService chatLogService;
     private final ChatSessionService chatSessionService;
     private final TokenProvider tokenProvider;
 
-    @Operation(summary = "일반 채팅 질문 전송 API", description ="상담원이 입력한 일반 법률 질문을 챗봇에게 전송하고 응답을 받아옵니다.")
+    @Operation(
+            summary = "일반 채팅 질문 전송 API",
+            description ="상담원이 입력한 일반 법률 질문을 챗봇에게 전송하고 응답을 받아옵니다."
+    )
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> streamChat(
             @Parameter(description = "대화가 기록될 ChatSession ID", required = true)
@@ -61,13 +65,10 @@ public class ChatStreamController {
 
         StringBuilder jsonBuffer = new StringBuilder();
 
-        return webClient.post()
-                .uri("ai/chat/stream")
-                .contentType(MediaType.APPLICATION_JSON)           // 추가
-                .accept(MediaType.TEXT_EVENT_STREAM)               // 추가
-                .bodyValue(Map.of("session_id", sessionId, "question", question))
-                .retrieve()
-                .bodyToFlux(String.class)
+        return chatbotClient.sendChatRequest(
+                        "/ai/chat/stream",
+                        Map.of("session_id", sessionId, "question", question)
+                )
                 .map(data -> data.replace("data:", "").trim())
                 .doOnNext(chunk -> {
                     if (chunk.startsWith("[JSON]")) {

--- a/src/main/java/callprotector/spring/global/client/ChatbotClient.java
+++ b/src/main/java/callprotector/spring/global/client/ChatbotClient.java
@@ -1,0 +1,33 @@
+package callprotector.spring.global.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.beans.factory.annotation.Value;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatbotClient {
+
+    private final WebClient webClient;
+
+    @Value("${chatbot.url}")
+    private String chatbotUrl;
+
+    public Flux<String> sendChatRequest(String endpoint, Map<String, Object> payload) {
+        return webClient.post()
+                .uri(chatbotUrl + endpoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToFlux(String.class);
+    }
+
+}

--- a/src/main/java/callprotector/spring/global/config/WebClientConfig.java
+++ b/src/main/java/callprotector/spring/global/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package callprotector.spring.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,9 +11,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        show_sql: true
-        format_sql: true
-        use_sql_comments: true
+        show_sql: false
+        format_sql: false
+        use_sql_comments: false
         hbm2ddl:
           auto: update
         default_batch_fetch_size: 1000
@@ -63,3 +63,6 @@ elasticsearch:
 
 fastapi:
   url: http://localhost:8000/api/abuse/filter
+
+chatbot:
+  url: http://localhost:8000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -63,3 +63,6 @@ elasticsearch:
 
 fastapi:
   url: http://abusefilter:8080/api/abuse/filter
+
+chatbot:
+  url: http://chatbot:8000


### PR DESCRIPTION
## 📌 작업 내용
- Chatbot FastAPI 서버와 Spring 간 연동 구조 개선 및 Chatbot 서버 배포를 진행하기 위해
   환경별 url 분리 + WebClient 관련 리팩토링을 진행했습니다.

## 📝 변경 사항
- [x] application-local.yml / application-prod.yml에 환경별 url 분리
- [x] WebClientConfig 클래스 추가
- [x] 호출 로직을 공통화하기 위한 ChatbotClient 추가
- [x] ChatStreamController, CallChatStreamController, CallChatbotServiceImpl ChatbotClient 기반으로 리팩토링

## 🔗 관련 이슈
- closes #162 

## 📸 스크린샷 (선택)
- 배포 환경에서 챗봇 관련 API 테스트 완료했습니다 !
<img width="1278" height="701" alt="image" src="https://github.com/user-attachments/assets/8a437003-425e-4f3d-803b-c2ce0f5e7f50" />