### PR TITLE
:recycle: Refactor: 채팅 엔티티에서 중복 의미 필드 제거

### DIFF
--- a/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
+++ b/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
@@ -5,7 +5,6 @@ import callprotector.spring.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,16 +23,11 @@ public class ChatSession extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private LocalDateTime startTime;
-
-    private LocalDateTime endTime;
-
     @Column(nullable = false)
     private Integer status; // 1. 진행 중, 2:종료
 
     @Setter
-    private String title; // title 필드 추가
-
+    private String title;
 
     @Builder.Default
     @OneToMany(mappedBy = "chatSession", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
+++ b/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
@@ -4,12 +4,11 @@ import callprotector.spring.domain.chat.entity.ChatSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
 
-    List<ChatSession> findByUserIdOrderByStartTimeDesc(Long userId);
+    List<ChatSession> findByUserIdOrderByCreatedAtDesc(Long userId);
 
 }

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -36,7 +35,6 @@ public class ChatSessionServiceImpl implements ChatSessionService{
 
         ChatSession session = ChatSession.builder()
                 .user(user)
-                .startTime(LocalDateTime.now())
                 .status(1) // 진행 중
                 .build();
 
@@ -44,7 +42,7 @@ public class ChatSessionServiceImpl implements ChatSessionService{
 
         return ChatSessionResponseDTO.ChatSessionResponse.builder()
                 .sessionId(saved.getId())
-                .startTime(saved.getStartTime().toString())
+                .startTime(saved.getCreatedAt().toString())
                 .title(saved.getTitle()) // title 추가
                 .build();
     }
@@ -58,25 +56,18 @@ public class ChatSessionServiceImpl implements ChatSessionService{
             chatSessionRepository.save(session);
         }
         return session.getTitle();
-
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<ChatSessionResponseDTO.ChatSessionResponse> getSessionList(Long userId) {
-        return chatSessionRepository.findByUserIdOrderByStartTimeDesc(userId).stream()
+        return chatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
                 .map(session -> ChatSessionResponseDTO.ChatSessionResponse.builder()
                         .sessionId(session.getId())
                         .title(session.getTitle())
-                        .startTime(session.getStartTime().toString())
+                        .startTime(session.getCreatedAt().toString())
                         .build())
                 .toList();
     }
-
     // getSessionDetail 함수 하려는데, ScriptHistoryRepository 뭐꼬 이거;; (MongoRepository로 callSessionId 기준 스크립트 이력 조회해야된다는데)
-
-
-
-
-
 }


### PR DESCRIPTION
## 📌 작업 내용
채팅 엔티티에서 중복 의미 필드 제거

## 📝 변경 사항
- [x] 채팅 엔티티에서 중복 의미 필드 제거
- [x] repository 메서드명 변경
- [x] DB 반영

## 🔗 관련 이슈
- closes #173

## 📸 스크린샷 (선택)
- ERD CLOUD 반영 완료
<img width="478" height="194" alt="image" src="https://github.com/user-attachments/assets/02f4a31f-28c4-4e82-b9a0-c7f724354b9e" />

