### PR TITLE
:bug: Fix: 비프음 발생 이후 음성 차단 오류 수정

### DIFF
--- a/src/main/java/callprotector/spring/global/handler/SttContext.java
+++ b/src/main/java/callprotector/spring/global/handler/SttContext.java
@@ -436,11 +436,18 @@ public class SttContext {
 		if (userId == null) return;
 		long now = System.currentTimeMillis();
 		if (now - lastBeepAt < BEEP_COOLDOWN_MS) return;
+
+		sttWebSocketHandler.sendSttToClient(userId, Map.of(
+				"type", "mute",
+				"ts", now
+		));
+
 		sttWebSocketHandler.sendSttToClient(userId, Map.of(
 				"type", "beep",
 				"durationMs", durationMs,
 				"ts", now
 		));
+
 		lastBeepAt = now;
 		log.info("🔔 비프 트리거 전송 (userId={}, durationMs={})", userId, durationMs);
 	}


### PR DESCRIPTION
## 📌 작업 내용
- 폭언 감지 시 고객 음성이 비프음과 겹쳐 들리는 문제를 해결하기 위해 mute 이벤트를 추가했습니다.

## 📝 변경 사항
- [x] SttContext.java 내 sendBeepIfAllowed()에 mute 이벤트 추가

## 🔗 관련 이슈
- closes #184

## 📸 스크린샷 (선택)
