### PR TITLE
✨ Feat: 통화 강제 종료 시 폭언 유형 누락 방지 로직 추가

### DIFF
--- a/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
@@ -124,7 +124,24 @@ public class CallSessionServiceImpl implements CallSessionService {
                 if (customerPhone == null || customerPhone.isBlank()) {
                     log.warn("❗ 고객 번호가 없어 종료 안내 SMS 발송을 생략합니다. sessionId={}", callSession.getId());
                 } else {
-                    Set<String> labels = buildAbuseLabels(callSession.getId());
+                    final int maxTries = 15;
+                    final long intervalMs = 200;
+                    Set<String> labels = new LinkedHashSet<>();
+
+                    for (int i = 0; i < maxTries; i++) {
+                        labels = buildAbuseLabels(callSession.getId());
+                        if (!(labels.size() == 1 && labels.contains("부적절한 발언"))) {
+                            if (i > 0) {
+                                log.info("통화 종료 직후 {}회 재조회 후 폭언 유형 감지: {}", i + 1, labels);
+                            }
+                            break;
+                        }
+                        try { Thread.sleep(intervalMs); } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+
                     try {
                         smsService.sendTerminationNotice(customerPhone, labels);
                         log.info("✅ 통화 강제 종료 사유 SMS 발송 완료 - to={}, types={}", customerPhone, labels);
@@ -646,7 +663,7 @@ public class CallSessionServiceImpl implements CallSessionService {
                 .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_ThreatTrue(sessionId)) {
             labels.add("협박");
         }
-        if (labels.isEmpty()) labels.add("폭언");
+        if (labels.isEmpty()) labels.add("부적절한 발언");
         return labels;
     }
 }

--- a/src/main/java/callprotector/spring/global/sms/service/SmsServiceImpl.java
+++ b/src/main/java/callprotector/spring/global/sms/service/SmsServiceImpl.java
@@ -25,7 +25,7 @@ public class SmsServiceImpl implements SmsService {
         String from = normalizePhone(sender);
 
         String joinedTypes = String.join(", ", (abuseTypes == null || abuseTypes.isEmpty())
-                ? Set.of("폭언") : abuseTypes);
+                ? Set.of("부적절한 발언") : abuseTypes);
         String text = "[CallProtector] 폭언(" + joinedTypes + ") 3회 발생으로 인해 통화가 종료되었습니다.";
 
         Message m = new Message();


### PR DESCRIPTION
## 📌 작업 내용
- 통화 종료 직후 DB 반영 지연으로 SMS 발송 시 폭언 유형이 누락되는 문제를 방지하기 위해
3초 간 재조회 후 폭언 유형이 감지되면 발송되도록 누락 방지 로직을 추가했습니다.

## 📝 변경 사항
- [x] callSessionServiceImpl 내 forceTerminateCall에 폭언 유형 재조회 로직 추가

## 🔗 관련 이슈
- closes #193 

## 📸 스크린샷 (선택)
