### PR TITLE
♻️ Refactor: 통화 강제 종료 시 SMS 발송 기능 수정

### DIFF
--- a/src/main/java/callprotector/spring/domain/abuse/service/AbuseServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/abuse/service/AbuseServiceImpl.java
@@ -1,6 +1,7 @@
 package callprotector.spring.domain.abuse.service;
 
 import callprotector.spring.domain.abuse.dto.response.AbuseResponseDTO;
+import callprotector.spring.domain.callsession.entity.CallSession;
 import callprotector.spring.global.client.FastClient;
 import callprotector.spring.domain.abuse.entity.AbuseLog;
 import callprotector.spring.domain.abuse.entity.AbuseType;
@@ -9,12 +10,15 @@ import callprotector.spring.domain.abuse.entity.AbuseTypeLog;
 import callprotector.spring.domain.abuse.repository.AbuseLogRepository;
 import callprotector.spring.domain.abuse.repository.AbuseTypeLogRepository;
 import callprotector.spring.domain.abuse.repository.AbuseTypeRepository;
+import callprotector.spring.global.sms.service.SmsService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -26,6 +30,8 @@ public class AbuseServiceImpl implements AbuseService{
     private final AbuseLogRepository abuseLogRepository;
     private final AbuseTypeRepository abuseTypeRepository;
     private final AbuseTypeLogRepository abuseTypeLogRepository;
+
+    private final SmsService smsService;
 
     @Override
     public AbuseResponseDTO.AbuseFilterDTO analyzeText(String text) {
@@ -63,6 +69,52 @@ public class AbuseServiceImpl implements AbuseService{
                 abuseType.isSexualHarass(),
                 abuseType.isThreat()
         );
+
+        try {
+            CallSession session = callLog.getCallSession();
+
+            if (session == null) {
+                log.warn("❗ CallLog에 연결된 CallSession이 없습니다. callLogId={}", callLog.getId());
+                return;
+            }
+            if (!session.isForcedTerminated()) {
+                // 강제 종료가 아닌 일반 종료라면 전송 X
+                return;
+            }
+            if (session.getTotalAbuseCnt() < 3) {
+                // 폭언이 3회 이상인 경우만 전송
+                return;
+            }
+
+            String to = session.getCallerNumber();
+
+            if (to == null || to.isBlank()) {
+                log.warn("❗ 고객 번호가 없어 종료 안내 SMS 발송을 생략합니다. sessionId={}", session.getId());
+                return;
+            }
+
+            Set<String> labels = new LinkedHashSet<>();
+            if (abuseTypeLogRepository
+                    .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_VerbalAbuseTrue(session.getId())) {
+                labels.add("욕설");
+            }
+            if (abuseTypeLogRepository
+                    .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_SexualHarassTrue(session.getId())) {
+                labels.add("성희롱");
+            }
+            if (abuseTypeLogRepository
+                    .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_ThreatTrue(session.getId())) {
+                labels.add("협박");
+            }
+            if (labels.isEmpty()) labels.add("부적절한 발언");
+
+            smsService.sendTerminationNotice(to, labels);
+            log.info("✅ 통화 강제 종료 사유 SMS 발송 완료 - to={}, types={}\"", to, labels);
+
+        } catch (Exception e) {
+            log.error("❌ 통화 강제 종료 사유 SMS 발송 실패 - callLogId={}, err={}", callLog.getId(), e.getMessage(), e);
+        }
+
     }
 
 }

--- a/src/main/java/callprotector/spring/domain/callsession/entity/CallSession.java
+++ b/src/main/java/callprotector/spring/domain/callsession/entity/CallSession.java
@@ -56,6 +56,10 @@ public class CallSession extends BaseEntity {
     @Column(name= "summary_detailed", length = 2000)
     private String summaryDetailed;
 
+    // 통화 강제 종료 여부
+    @Column(nullable = false)
+    private boolean forcedTerminated = false;
+
     public void updateAbuseCnt() {
         this.totalAbuseCnt = (this.totalAbuseCnt == null ? 0 : this.totalAbuseCnt) + 1;
     }
@@ -79,4 +83,7 @@ public class CallSession extends BaseEntity {
     public void updateUser(User user) {
         this.user = user;
     }
+
+    public void markForcedTerminated() { this.forcedTerminated = true; }
+
 }

--- a/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callsession/service/CallSessionServiceImpl.java
@@ -118,37 +118,10 @@ public class CallSessionServiceImpl implements CallSessionService {
                 Call.updater(callSid).setStatus(Call.UpdateStatus.COMPLETED).update();
                 log.info("Twilio Call SID {} - 통화 종료 성공.", callSid);
 
+                callSession.markForcedTerminated();
+
                 callSession.updateEndedAt();
 
-                String customerPhone = callSession.getCallerNumber();
-                if (customerPhone == null || customerPhone.isBlank()) {
-                    log.warn("❗ 고객 번호가 없어 종료 안내 SMS 발송을 생략합니다. sessionId={}", callSession.getId());
-                } else {
-                    final int maxTries = 15;
-                    final long intervalMs = 200;
-                    Set<String> labels = new LinkedHashSet<>();
-
-                    for (int i = 0; i < maxTries; i++) {
-                        labels = buildAbuseLabels(callSession.getId());
-                        if (!(labels.size() == 1 && labels.contains("부적절한 발언"))) {
-                            if (i > 0) {
-                                log.info("통화 종료 직후 {}회 재조회 후 폭언 유형 감지: {}", i + 1, labels);
-                            }
-                            break;
-                        }
-                        try { Thread.sleep(intervalMs); } catch (InterruptedException ie) {
-                            Thread.currentThread().interrupt();
-                            break;
-                        }
-                    }
-
-                    try {
-                        smsService.sendTerminationNotice(customerPhone, labels);
-                        log.info("✅ 통화 강제 종료 사유 SMS 발송 완료 - to={}, types={}", customerPhone, labels);
-                    } catch (Exception e) {
-                        log.error("❌ 통화 강제 종료 사유 SMS 발송 실패 - sessionId={}, err={}", callSession.getId(), e.getMessage(), e);
-                    }
-                }
             } catch (ApiException e) {
                 log.error("❌ Twilio 통화 종료 실패 (Call SID: {}): {}", callSid, e.getMessage(), e);
             }
@@ -649,21 +622,4 @@ public class CallSessionServiceImpl implements CallSessionService {
             .build();
     }
 
-    private Set<String> buildAbuseLabels(Long sessionId) {
-        Set<String> labels = new LinkedHashSet<>();
-        if (abuseTypeLogRepository
-                .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_VerbalAbuseTrue(sessionId)) {
-            labels.add("욕설");
-        }
-        if (abuseTypeLogRepository
-                .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_SexualHarassTrue(sessionId)) {
-            labels.add("성희롱");
-        }
-        if (abuseTypeLogRepository
-                .existsByAbuseLog_CallLog_CallSession_IdAndAbuseType_ThreatTrue(sessionId)) {
-            labels.add("협박");
-        }
-        if (labels.isEmpty()) labels.add("부적절한 발언");
-        return labels;
-    }
 }


### PR DESCRIPTION
## 📌 작업 내용
- 기존 callSessionServiceImpl 내 존재하던 SMS 발송 기능을 전체적인 통화 흐름을 고려해 abuseTypeServiceImpl로 이동했습니다.

## 📝 변경 사항
- [x] callSession 엔티티 내 forcedTerminated 필드 추가
- [x] SMS 발송 기능 callSessionServiceImpl → abuseServiceImpl로 이동

## 🔗 관련 이슈
- closes #193 

## 📸 스크린샷 (선택)
![sms](https://github.com/user-attachments/assets/7805660e-9864-497a-9413-da71cc456f87)

