### PR TITLE
Refactor: 챗 세션 정렬 수정

### DIFF
--- a/src/main/java/callprotector/spring/domain/callchat/entity/CallChatSession.java
+++ b/src/main/java/callprotector/spring/domain/callchat/entity/CallChatSession.java
@@ -14,6 +14,12 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(
+        name = "call_chat_session",
+        indexes = {
+                @Index(name = "idx_call_chat_session_user_last_question", columnList = "user_id,last_user_question_at")
+        }
+)
 public class CallChatSession extends BaseEntity {
 
     @Id

--- a/src/main/java/callprotector/spring/domain/callchat/entity/CallChatSession.java
+++ b/src/main/java/callprotector/spring/domain/callchat/entity/CallChatSession.java
@@ -6,6 +6,7 @@ import callprotector.spring.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,4 +37,12 @@ public class CallChatSession extends BaseEntity {
 
     @OneToMany(mappedBy = "callChatSession", cascade = CascadeType.ALL)
     private List<CallChatLog> logs = new ArrayList<>();
+
+    // 마지막 사용자 질문 시각(denorm)
+    @Column(name = "last_user_question_at")
+    private LocalDateTime lastUserQuestionAt;
+
+    public void touchLastUserQuestionAt(LocalDateTime t) {
+        this.lastUserQuestionAt = t;
+    }
 }

--- a/src/main/java/callprotector/spring/domain/callchat/repository/CallChatSessionRepository.java
+++ b/src/main/java/callprotector/spring/domain/callchat/repository/CallChatSessionRepository.java
@@ -3,13 +3,24 @@ package callprotector.spring.domain.callchat.repository;
 import callprotector.spring.domain.callchat.entity.CallChatSession;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface CallChatSessionRepository extends JpaRepository<CallChatSession, Long> {
-    List<CallChatSession> findByUserIdOrderByLastUserQuestionAtDesc(Long userId);
+    @Query("""
+        select cs
+        from CallChatSession cs
+        where cs.user.id = :userId
+        order by 
+            case when cs.lastUserQuestionAt is null then 1 else 0 end,
+            cs.lastUserQuestionAt desc,
+            cs.id desc
+        """)
+    List<CallChatSession> findAllForUserOrderByLastUserQuestion(@Param("userId")Long userId);
 
     // CallChatSessionRepository
     Optional<CallChatSession> findByUserIdAndCallSessionId(Long userId, Long callSessionId);

--- a/src/main/java/callprotector/spring/domain/callchat/repository/CallChatSessionRepository.java
+++ b/src/main/java/callprotector/spring/domain/callchat/repository/CallChatSessionRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Repository
 public interface CallChatSessionRepository extends JpaRepository<CallChatSession, Long> {
-    List<CallChatSession> findByUserIdOrderByIdDesc(Long userId);
+    List<CallChatSession> findByUserIdOrderByLastUserQuestionAtDesc(Long userId);
 
     // CallChatSessionRepository
     Optional<CallChatSession> findByUserIdAndCallSessionId(Long userId, Long callSessionId);

--- a/src/main/java/callprotector/spring/domain/callchat/service/CallChatLogServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callchat/service/CallChatLogServiceImpl.java
@@ -30,18 +30,18 @@ public class CallChatLogServiceImpl implements CallChatLogService {
         try {
             CallChatSession session = callChatSessionService.getSessionById(sessionId);
 
-            CallChatLog log = CallChatLog.builder()
-                    .callChatSession(session)
-                    .question(question)
-                    .answer(answer)
-                    .sourcePages(sourcePages)
-                    .build();
-
-            callChatLogRepository.save(log);
+            CallChatLog saved = callChatLogRepository.save(
+                    CallChatLog.builder()
+                            .callChatSession(session)
+                            .question(question)
+                            .answer(answer)
+                            .sourcePages(sourcePages)
+                            .build()
+            );
 
             // 사용자 질문이 존재하면 마지막 사용자 질문 시각 갱신
             if (question != null && !question.isBlank()) {
-                session.touchLastUserQuestionAt(LocalDateTime.now());
+                session.touchLastUserQuestionAt(saved.getCreatedAt());
             }
 
 

--- a/src/main/java/callprotector/spring/domain/callchat/service/CallChatLogServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callchat/service/CallChatLogServiceImpl.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -21,7 +22,6 @@ import java.util.List;
 public class CallChatLogServiceImpl implements CallChatLogService {
 
     private final CallChatLogRepository callChatLogRepository;
-
     private final CallChatSessionService callChatSessionService;
 
     @Override
@@ -38,6 +38,13 @@ public class CallChatLogServiceImpl implements CallChatLogService {
                     .build();
 
             callChatLogRepository.save(log);
+
+            // 사용자 질문이 존재하면 마지막 사용자 질문 시각 갱신
+            if (question != null && !question.isBlank()) {
+                session.touchLastUserQuestionAt(LocalDateTime.now());
+            }
+
+
         } catch (Exception e) {
             log.error("❌ 상담별 채팅 로그 저장 실패", e);
             throw new CallChatGeneralException(ErrorStatus.CALLCHAT_LOG_SAVE_FAILED);

--- a/src/main/java/callprotector/spring/domain/callchat/service/CallChatSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callchat/service/CallChatSessionServiceImpl.java
@@ -49,7 +49,7 @@ public class CallChatSessionServiceImpl implements CallChatSessionService {
     @Override
     @Transactional(readOnly = true)
     public List<CallChatSessionResponseDTO.CallChatSessionResponse> getSessionListDtoByUserId(Long userId) {
-        return callChatSessionRepository.findByUserIdOrderByLastUserQuestionAtDesc(userId).stream()
+        return callChatSessionRepository.findAllForUserOrderByLastUserQuestion(userId).stream()
                 .map(session -> CallChatSessionResponseDTO.CallChatSessionResponse.builder()
                         .sessionId(session.getId())
                         .createdAt(session.getCreatedAt().toString()) // BaseEntity.getCreatedAt()

--- a/src/main/java/callprotector/spring/domain/callchat/service/CallChatSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/callchat/service/CallChatSessionServiceImpl.java
@@ -49,7 +49,7 @@ public class CallChatSessionServiceImpl implements CallChatSessionService {
     @Override
     @Transactional(readOnly = true)
     public List<CallChatSessionResponseDTO.CallChatSessionResponse> getSessionListDtoByUserId(Long userId) {
-        return callChatSessionRepository.findByUserIdOrderByIdDesc(userId).stream()
+        return callChatSessionRepository.findByUserIdOrderByLastUserQuestionAtDesc(userId).stream()
                 .map(session -> CallChatSessionResponseDTO.CallChatSessionResponse.builder()
                         .sessionId(session.getId())
                         .createdAt(session.getCreatedAt().toString()) // BaseEntity.getCreatedAt()

--- a/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
+++ b/src/main/java/callprotector/spring/domain/chat/entity/ChatSession.java
@@ -5,6 +5,7 @@ import callprotector.spring.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +14,12 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(
+        name = "chat_session",
+        indexes = {
+                @Index(name = "idx_chat_session_user_last_question", columnList = "user_id,last_user_question_at")
+        }
+)
 public class ChatSession extends BaseEntity {
 
     @Id
@@ -32,6 +39,14 @@ public class ChatSession extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "chatSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatLog> chatLogs = new ArrayList<>();
+
+    // 마지막 사용자 질문 시각(denorm)
+    @Column(name = "last_user_question_at")
+    private LocalDateTime lastUserQuestionAt;
+
+    public void touchLastUserQuestionAt(LocalDateTime t) {
+        this.lastUserQuestionAt = t;
+    }
 
 
 }

--- a/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
+++ b/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Repository
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
 
-    List<ChatSession> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<ChatSession> findByUserIdOrderByLastUserQuestionAtDesc(Long userId);
 
 }

--- a/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
+++ b/src/main/java/callprotector/spring/domain/chat/repository/ChatSessionRepository.java
@@ -2,6 +2,8 @@ package callprotector.spring.domain.chat.repository;
 
 import callprotector.spring.domain.chat.entity.ChatSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,6 +11,14 @@ import java.util.List;
 @Repository
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
 
-    List<ChatSession> findByUserIdOrderByLastUserQuestionAtDesc(Long userId);
-
+    @Query("""
+        select cs
+        from ChatSession cs
+        where cs.user.id = :userId
+        order by
+            case when cs.lastUserQuestionAt is null then 1 else 0 end,
+            cs.lastUserQuestionAt desc,
+            cs.id desc
+        """)
+    List<ChatSession> findAllForUserOrderByLastUserQuestion(@Param("userId") Long userId);
 }

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatLogServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatLogServiceImpl.java
@@ -35,15 +35,17 @@ public class ChatLogServiceImpl implements ChatLogService {
         try {
             ChatSession session = chatSessionService.getSessionById(sessionId);
 
-            chatLogRepository.save(ChatLog.builder()
-                    .chatSession(session)
-                    .question(question)
-                    .answer(answer)
-                    .sourcePages(sourcePages)
-                    .build());
+            ChatLog saved = chatLogRepository.save(
+                    ChatLog.builder()
+                            .chatSession(session)
+                            .question(question)
+                            .answer(answer)
+                            .sourcePages(sourcePages)
+                            .build()
+            );
             // 사용자 질문이 존재하면 마지막 사용자 질문 시각 갱신
             if (question != null && !question.isBlank()) {
-                session.touchLastUserQuestionAt(LocalDateTime.now());
+                session.touchLastUserQuestionAt(saved.getCreatedAt());
             }
         } catch (Exception e) {
             log.error("❌ 채팅 로그 저장 실패", e);

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatLogServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatLogServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -40,6 +41,10 @@ public class ChatLogServiceImpl implements ChatLogService {
                     .answer(answer)
                     .sourcePages(sourcePages)
                     .build());
+            // 사용자 질문이 존재하면 마지막 사용자 질문 시각 갱신
+            if (question != null && !question.isBlank()) {
+                session.touchLastUserQuestionAt(LocalDateTime.now());
+            }
         } catch (Exception e) {
             log.error("❌ 채팅 로그 저장 실패", e);
             throw new ChatGeneralException(ErrorStatus.CHAT_LOG_SAVE_FAILED);

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
@@ -63,7 +63,7 @@ public class ChatSessionServiceImpl implements ChatSessionService{
     @Override
     @Transactional(readOnly = true)
     public List<ChatSessionResponseDTO.ChatSessionResponse> getSessionList(Long userId) {
-        return chatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+        return chatSessionRepository.findByUserIdOrderByLastUserQuestionAtDesc(userId).stream()
                 .map(session -> ChatSessionResponseDTO.ChatSessionResponse.builder()
                         .sessionId(session.getId())
                         .title(session.getTitle())

--- a/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
+++ b/src/main/java/callprotector/spring/domain/chat/service/ChatSessionServiceImpl.java
@@ -63,7 +63,7 @@ public class ChatSessionServiceImpl implements ChatSessionService{
     @Override
     @Transactional(readOnly = true)
     public List<ChatSessionResponseDTO.ChatSessionResponse> getSessionList(Long userId) {
-        return chatSessionRepository.findByUserIdOrderByLastUserQuestionAtDesc(userId).stream()
+        return chatSessionRepository.findAllForUserOrderByLastUserQuestion(userId).stream()
                 .map(session -> ChatSessionResponseDTO.ChatSessionResponse.builder()
                         .sessionId(session.getId())
                         .title(session.getTitle())

--- a/src/main/java/callprotector/spring/domain/user/entity/VerificationToken.java
+++ b/src/main/java/callprotector/spring/domain/user/entity/VerificationToken.java
@@ -20,7 +20,7 @@ public class VerificationToken {
 
     private LocalDateTime expiresAt;
 
-    private boolean verified; // ✅ 인증 완료 여부 저장
+    private boolean verified; // 인증 완료 여부 저장
 
     public static VerificationToken create(String email, String code) {
         VerificationToken token = new VerificationToken();

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,7 +59,7 @@ gcp:
 elasticsearch:
   host: localhost
   port: 9200
-  enabled: true
+  enabled: false
 
 fastapi:
   url: http://localhost:8000/api/abuse/filter


### PR DESCRIPTION
## 📌 작업 내용
- 챗 세션 정렬을 세션생성 시간 기준 → 사용자 마지막 질문 시간 기준 정렬로 변경했습니다.

## 📝 변경 사항
- [x] ChatSession 엔티티에 lastUserQuestionAt 필드 추가
- [x] CallChatSession 엔티티에 lastUserQuestionAt 필드 추가
- [x] ChatSessionRepository lastUserQuestionAt기준 내림차순 정렬
- [x] CallChatSessionRepository lastUserQuestionAt기준 내림차순 정렬
- [x] ChatSession 조회 api 정렬메소드 수정
- [x] CallChatSession 조회 서비스 로직 정렬메소드 수정
- [x] ChatLogService 저장시점 -> 마지막 사용자 질문 시각으로 갱신
- [x] CallChatLogService 저장 시점 -> 마지막 사용자 질문 시각으로 갱신
- [x] 배포 DB sort sessions by last user question; add last_user_quest… 적용


## 🔗 관련 이슈
- closes #이슈번호

## 📸 스크린샷 (선택)

<img width="653" height="238" alt="image" src="https://github.com/user-attachments/assets/8e90ec03-1370-4f4d-8911-d39485c6b846" />
<img width="1090" height="811" alt="image" src="https://github.com/user-attachments/assets/faf0185e-c8cc-4005-949d-ee430b17d8aa" />
