### PR TITLE
♻️ Refactor: 통화 강제 종료 SMS 텍스트 변경

### DIFF
--- a/src/main/java/callprotector/spring/global/sms/service/SmsServiceImpl.java
+++ b/src/main/java/callprotector/spring/global/sms/service/SmsServiceImpl.java
@@ -26,7 +26,7 @@ public class SmsServiceImpl implements SmsService {
 
         String joinedTypes = String.join(", ", (abuseTypes == null || abuseTypes.isEmpty())
                 ? Set.of("부적절한 발언") : abuseTypes);
-        String text = "[CallProtector] 폭언(" + joinedTypes + ") 3회 발생으로 인해 통화가 종료되었습니다.";
+        String text = "[온음] 폭언(" + joinedTypes + ") 3회 발생으로 인해 통화가 자동 종료되었습니다.";
 
         Message m = new Message();
         m.setFrom(from);


### PR DESCRIPTION
## 📌 작업 내용
- 통화 강제 종료 시 발송되는 SMS의 텍스트를 변경했습니다.

## 📝 변경 사항
- [x] [CallProtector] → [온음], 통화가 종료되었습니다 → 통화가 자동 종료되었습니다 로 수정

## 🔗 관련 이슈
- closes #201 

## 📸 스크린샷 (선택)
