### PR TITLE
♻️ Refactor: INBOUND STT 강제 최종 텍스트 처리 시간 10초로 수정

### DIFF
--- a/src/main/java/callprotector/spring/global/handler/TwilioMediaStreamProcessor.java
+++ b/src/main/java/callprotector/spring/global/handler/TwilioMediaStreamProcessor.java
@@ -44,7 +44,7 @@ public class TwilioMediaStreamProcessor {
 	private Long currentCallSessionId;
 	private String primaryCallSid;
 
-	private static final long STREAM_RESTART_INTERVAL_MS = 5_000;
+	private static final long STREAM_RESTART_INTERVAL_MS = 10_000;
 	private static final long TEMP_USERID = 1;
 
 	public void handleTwilioMessage(WebSocketSession session, TextMessage message) throws Exception {


### PR DESCRIPTION
## 📌 작업 내용
- 인바운드 STT 최종 텍스트 처리 시간을 기존 5초에서 10초로 수정했습니다.

## 📝 변경 사항
- [x] TwilioMediaStreamProcessor 내 STREAM_RESTART_INTERVAL_MS 10초로 수정

## 🔗 관련 이슈
- closes #206 

## 📸 스크린샷 (선택)
